### PR TITLE
Refactor widgets

### DIFF
--- a/packages/editor/src/components/parts/call/CallSelect.tsx
+++ b/packages/editor/src/components/parts/call/CallSelect.tsx
@@ -1,5 +1,4 @@
-import { Combobox, ComboboxItem, IvyIcon } from '../../widgets';
-import { Message } from '../../props/message';
+import { Combobox, ComboboxInputProps, ComboboxItem, IvyIcon } from '../../widgets';
 import { IvyIcons } from '@axonivy/editor-icons';
 import { CallableStart } from '@axonivy/inscription-protocol';
 
@@ -36,10 +35,9 @@ const CallSelect = (props: {
   start: string;
   onChange: (change: string) => void;
   starts: CallableStartItem[];
-  label: string;
   startIcon: IvyIcons;
   processIcon: IvyIcons;
-  message?: Message;
+  comboboxInputProps: ComboboxInputProps;
 }) => {
   const comboboxItem = (item: ComboboxItem) => {
     if (!CallableStartItem.is(item)) {
@@ -64,13 +62,12 @@ const CallSelect = (props: {
 
   return (
     <Combobox
-      label={props.label}
       items={props.starts}
       comboboxItem={comboboxItem}
       itemFilter={CallableStartItem.itemFilter}
       value={props.start}
       onChange={props.onChange}
-      message={props.message}
+      inputProps={props.comboboxInputProps}
     />
   );
 };

--- a/packages/editor/src/components/parts/call/dialog/DialogCallPart.tsx
+++ b/packages/editor/src/components/parts/call/dialog/DialogCallPart.tsx
@@ -6,6 +6,7 @@ import CallMapping from '../CallMapping';
 import { useCallData, useDialogCallData } from '../useCallData';
 import CallSelect, { CallableStartItem } from '../CallSelect';
 import { IvyIcons } from '@axonivy/editor-icons';
+import { Fieldset, useFieldset } from '../../../../components/widgets';
 
 function useCallPartValidation(): InscriptionValidation[] {
   const dialog = useValidation('config/dialog');
@@ -36,17 +37,20 @@ const DialogCallPart = () => {
     [dialogCallData.dialog, startItems]
   );
 
+  const callField = useFieldset();
+
   return (
     <>
-      <CallSelect
-        start={dialogCallData.dialog}
-        onChange={updateDialog}
-        starts={startItems}
-        label='Dialog'
-        startIcon={IvyIcons.InitStart}
-        processIcon={IvyIcons.Dialogs}
-        message={dialogValidation}
-      />
+      <Fieldset label='Dialog' message={dialogValidation} {...callField.labelProps}>
+        <CallSelect
+          start={dialogCallData.dialog}
+          onChange={updateDialog}
+          starts={startItems}
+          startIcon={IvyIcons.InitStart}
+          processIcon={IvyIcons.Dialogs}
+          comboboxInputProps={callField.inputProps}
+        />
+      </Fieldset>
       <CallMapping mappingInfo={mappingInfo} />
     </>
   );

--- a/packages/editor/src/components/parts/call/sub/SubCallPart.tsx
+++ b/packages/editor/src/components/parts/call/sub/SubCallPart.tsx
@@ -6,6 +6,7 @@ import CallMapping from '../CallMapping';
 import { useCallData, useProcessCallData } from '../useCallData';
 import CallSelect, { CallableStartItem } from '../CallSelect';
 import { IvyIcons } from '@axonivy/editor-icons';
+import { Fieldset, useFieldset } from '../../../../components/widgets';
 
 export function useSubCallPart(): PartProps {
   const { callData, defaultData } = useCallData();
@@ -29,16 +30,20 @@ const SubCallPart = () => {
     [processCallData.processCall, startItems]
   );
 
+  const callField = useFieldset();
+
   return (
     <>
-      <CallSelect
-        start={processCallData.processCall}
-        onChange={updateProcessCall}
-        starts={startItems}
-        label='Process start'
-        startIcon={IvyIcons.SubStart}
-        processIcon={IvyIcons.Sub}
-      />
+      <Fieldset label='Process start' {...callField.labelProps}>
+        <CallSelect
+          start={processCallData.processCall}
+          onChange={updateProcessCall}
+          starts={startItems}
+          startIcon={IvyIcons.SubStart}
+          processIcon={IvyIcons.Sub}
+          comboboxInputProps={callField.inputProps}
+        />
+      </Fieldset>
       <CallMapping mappingInfo={mappingInfo} />
     </>
   );

--- a/packages/editor/src/components/parts/call/trigger/TriggerCallPart.tsx
+++ b/packages/editor/src/components/parts/call/trigger/TriggerCallPart.tsx
@@ -6,6 +6,7 @@ import CallMapping from '../CallMapping';
 import { useCallData, useProcessCallData } from '../useCallData';
 import CallSelect, { CallableStartItem } from '../CallSelect';
 import { IvyIcons } from '@axonivy/editor-icons';
+import { Fieldset, useFieldset } from '../../../../components/widgets';
 
 export function useTriggerCallPart(): PartProps {
   const { callData, defaultData } = useCallData();
@@ -29,16 +30,20 @@ const TriggerCallPart = () => {
     [processCallData.processCall, startItems]
   );
 
+  const callField = useFieldset();
+
   return (
     <>
-      <CallSelect
-        start={processCallData.processCall}
-        onChange={updateProcessCall}
-        starts={startItems}
-        label='Process start'
-        startIcon={IvyIcons.Start}
-        processIcon={IvyIcons.Trigger}
-      />
+      <Fieldset label='Process start' {...callField.labelProps}>
+        <CallSelect
+          start={processCallData.processCall}
+          onChange={updateProcessCall}
+          starts={startItems}
+          startIcon={IvyIcons.Start}
+          processIcon={IvyIcons.Trigger}
+          comboboxInputProps={callField.inputProps}
+        />
+      </Fieldset>
       <CallMapping mappingInfo={mappingInfo} />
     </>
   );

--- a/packages/editor/src/components/parts/name/NamePart.tsx
+++ b/packages/editor/src/components/parts/name/NamePart.tsx
@@ -2,7 +2,7 @@ import { useValidation } from '../../../context';
 import { PartProps, usePartDirty, usePartState } from '../../props';
 import { InscriptionValidation } from '@axonivy/inscription-protocol';
 import DocumentTable from './document/DocumentTable';
-import { CollapsiblePart, Fieldset, SummaryFieldset, SummaryTags, Tags, Textarea } from '../../widgets';
+import { CollapsiblePart, Fieldset, SummaryFieldset, SummaryTags, Tags, Textarea, useFieldset } from '../../widgets';
 import { useNameData } from './useNameData';
 
 function useNamePartValidation(): InscriptionValidation[] {
@@ -34,13 +34,16 @@ const NamePart = (props: { hideTags?: boolean }) => {
   const descriptionData = { data: data.description, initData: initData.description, updateData: updateDescription };
   const docsData = { data: data.docs, initData: initData.docs, updateData: updateDocs };
 
+  const nameField = useFieldset();
+  const descriptionField = useFieldset();
+
   return (
     <>
-      <Fieldset label='Display name' htmlFor='displayName' data={nameData} message={nameValidation}>
-        <Textarea rows={1} id='displayName' data={nameData} />
+      <Fieldset label='Display name' data={nameData} message={nameValidation} {...nameField.labelProps}>
+        <Textarea rows={1} data={nameData} {...nameField.inputProps} />
       </Fieldset>
-      <Fieldset label='Description' htmlFor='description' data={descriptionData} message={descriptionValidation}>
-        <Textarea rows={2} id='description' data={descriptionData} />
+      <Fieldset label='Description' data={descriptionData} message={descriptionValidation} {...descriptionField.labelProps}>
+        <Textarea rows={2} data={descriptionData} {...descriptionField.inputProps} />
       </Fieldset>
       <Fieldset label='Means / Documents' data={docsData}>
         <DocumentTable data={docsData} />

--- a/packages/editor/src/components/parts/task/error/ErrorSelect.tsx
+++ b/packages/editor/src/components/parts/task/error/ErrorSelect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { EMPTY_SELECT_ITEM, Select, SelectItem } from '../../../widgets';
+import { EMPTY_SELECT_ITEM, Fieldset, Select, SelectItem, useFieldset } from '../../../widgets';
 import { useClient, useEditorContext } from '../../../../context';
 import { Consumer } from '../../../../types/lambda';
 
@@ -20,9 +20,18 @@ const ErrorSelect = (props: { error: string; updateError: Consumer<string> }) =>
 
   const selectedError = useMemo<SelectItem | undefined>(() => errorItems.find(e => e.value === props.error), [props.error, errorItems]);
 
+  const selectFieldset = useFieldset();
+
   return (
     <div className='error-select'>
-      <Select label='Error' items={errorItems} value={selectedError} onChange={item => props.updateError(item.value)} />
+      <Fieldset label='Error' {...selectFieldset.labelProps}>
+        <Select
+          items={errorItems}
+          value={selectedError}
+          onChange={item => props.updateError(item.value)}
+          inputProps={selectFieldset.inputProps}
+        />
+      </Fieldset>
     </div>
   );
 };

--- a/packages/editor/src/components/parts/task/expiry/ExpiryPart.test.tsx
+++ b/packages/editor/src/components/parts/task/expiry/ExpiryPart.test.tsx
@@ -24,8 +24,8 @@ describe('ExpiryPart', () => {
       responsible: { type: 'ROLE_FROM_ATTRIBUTE', activator: 'asdf' }
     });
     expect(screen.getByLabelText('Timeout')).toHaveValue('timeout');
-    await SelectUtil.assertEmpty('Error');
-    await SelectUtil.assertValue('Role from Attr.', 'Responsible');
-    await SelectUtil.assertValue('High', 'Priority');
+    await SelectUtil.assertEmpty({ label: 'Error' });
+    await SelectUtil.assertValue('Role from Attr.', { label: 'Responsible' });
+    await SelectUtil.assertValue('High', { label: 'Priority' });
   });
 });

--- a/packages/editor/src/components/parts/task/general/TaskPart.test.tsx
+++ b/packages/editor/src/components/parts/task/general/TaskPart.test.tsx
@@ -11,8 +11,8 @@ describe('TaskPart', () => {
     expect(screen.getByLabelText('Name')).toHaveValue(name);
     expect(screen.getByLabelText('Description')).toHaveValue(description);
     expect(screen.getByLabelText('Category')).toHaveValue(category);
-    await SelectUtil.assertValue(responsible, 'Responsible');
-    await SelectUtil.assertValue(priority, 'Priority');
+    await SelectUtil.assertValue(responsible, { label: 'Responsible' });
+    await SelectUtil.assertValue(priority, { label: 'Priority' });
 
     if (code) {
       await CollapsableUtil.assertOpen('Code');
@@ -25,12 +25,12 @@ describe('TaskPart', () => {
   test('task part render empty', async () => {
     renderTaskPart();
     await assertMainPart('', '', '', 'Role', 'Normal');
-    await SelectUtil.assertValue('Everybody', 'Role');
+    await SelectUtil.assertValue('Everybody', { index: 1 });
   });
 
   test('task part render skip task list option', async () => {
     renderTaskPart(undefined);
-    expect(SelectUtil.combobox('Responsible')).toBeInTheDocument();
+    expect(SelectUtil.select({ label: 'Responsible' })).toBeInTheDocument();
 
     const optionCollapse = screen.getByRole('button', { name: /Option/ });
     await userEvent.click(optionCollapse);

--- a/packages/editor/src/components/parts/task/priority/PrioritySelect.css
+++ b/packages/editor/src/components/parts/task/priority/PrioritySelect.css
@@ -1,9 +1,10 @@
-.priority-select .select-input {
-  gap: 1rem;
+.priority-select {
+  display: flex;
+  gap: var(--size-4);
 }
-.priority-select .select-button {
-  flex: 0 0 6rem;
+.priority-select .select:first-child {
+  flex: 0 0 8rem;
 }
-.priority-select .select-input .input {
-  width: calc(100% - 7rem);
+.priority-select .input {
+  width: calc(100% - 8rem - var(--size-4));
 }

--- a/packages/editor/src/components/parts/task/priority/PrioritySelect.tsx
+++ b/packages/editor/src/components/parts/task/priority/PrioritySelect.tsx
@@ -1,7 +1,7 @@
 import './PrioritySelect.css';
 import { useMemo } from 'react';
 import { WfPriority, WfLevel, PRIORITY_LEVEL } from '@axonivy/inscription-protocol';
-import { Select, SelectItem } from '../../../../components/widgets';
+import { Fieldset, Input, Select, SelectItem, useFieldset } from '../../../../components/widgets';
 import { Consumer } from '../../../../types/lambda';
 
 const DEFAULT_PRIORITY: SelectItem & { value: WfLevel } = { label: PRIORITY_LEVEL.NORMAL, value: 'NORMAL' };
@@ -11,33 +11,29 @@ export interface PriorityUpdater {
   updateScript: Consumer<string>;
 }
 
-const PriorityScript = (props: { priority?: WfPriority; updatePriority: PriorityUpdater; selectedLevel: WfLevel }) => {
-  if (props.selectedLevel === 'SCRIPT') {
-    return (
-      <input className='input' value={props.priority?.script ?? ''} onChange={e => props.updatePriority.updateScript(e.target.value)} />
-    );
-  }
-  return <></>;
-};
-
-const PrioritySelect = (props: { priority?: WfPriority; updatePriority: PriorityUpdater }) => {
+const PrioritySelect = ({ priority, updatePriority }: { priority?: WfPriority; updatePriority: PriorityUpdater }) => {
   const priorityItems = useMemo<SelectItem[]>(() => Object.entries(PRIORITY_LEVEL).map(([value, label]) => ({ label, value })), []);
   const selectedLevel = useMemo<SelectItem>(
-    () => priorityItems.find(e => e.value === props.priority?.level) ?? DEFAULT_PRIORITY,
-    [props.priority?.level, priorityItems]
+    () => priorityItems.find(e => e.value === priority?.level) ?? DEFAULT_PRIORITY,
+    [priority?.level, priorityItems]
   );
 
+  const selectFieldset = useFieldset();
+
   return (
-    <div className='priority-select'>
-      <Select
-        label='Priority'
-        value={selectedLevel}
-        onChange={item => props.updatePriority.updateLevel(item.value as WfLevel)}
-        items={priorityItems}
-      >
-        <PriorityScript {...props} selectedLevel={selectedLevel.value as WfLevel} />
-      </Select>
-    </div>
+    <Fieldset label='Priority' {...selectFieldset.labelProps}>
+      <div className='priority-select'>
+        <Select
+          value={selectedLevel}
+          onChange={item => updatePriority.updateLevel(item.value as WfLevel)}
+          items={priorityItems}
+          inputProps={selectFieldset.inputProps}
+        />
+        {(selectedLevel.value as WfLevel) === 'SCRIPT' && (
+          <Input value={priority?.script} onChange={change => updatePriority.updateScript(change)} />
+        )}
+      </div>
+    </Fieldset>
   );
 };
 

--- a/packages/editor/src/components/parts/task/responsible/ResponsibleSelect.css
+++ b/packages/editor/src/components/parts/task/responsible/ResponsibleSelect.css
@@ -1,22 +1,10 @@
-.responsible-select .select-input {
+.responsible-select {
+  display: flex;
   gap: var(--size-4);
 }
-.responsible-select .select-button {
-  flex: 0 0 6rem;
+.responsible-select .select:first-child {
+  flex: 0 0 8rem;
 }
-.responsible-select .select-input .input {
-  width: calc(100% - 6rem - var(--size-4));
-}
-.responsible-select .select-input .select-input .select-button {
-  flex: 0 1 auto;
-}
-.responsible-select .select-input .select .select-menu {
-  top: unset;
-  margin: 0;
-}
-.responsible-select .select-input .fieldset-column {
-  gap: 0;
-}
-.responsible-select .select-input .fieldset-column .fieldset-label {
-  display: none;
+.responsible-select .input {
+  width: calc(100% - 8rem - var(--size-4));
 }

--- a/packages/editor/src/components/parts/task/responsible/ResponsibleSelect.test.tsx
+++ b/packages/editor/src/components/parts/task/responsible/ResponsibleSelect.test.tsx
@@ -22,44 +22,44 @@ describe('ResponsibleSelect', () => {
 
   test('responsible select will render all options', async () => {
     renderSelect();
-    await SelectUtil.assertValue('Role', 'Responsible');
-    await SelectUtil.assertOptionsCount(4, 'Responsible');
+    await SelectUtil.assertValue('Role', { label: 'Responsible' });
+    await SelectUtil.assertOptionsCount(4, { label: 'Responsible' });
   });
 
   test('responsible select will render no delete option', async () => {
     renderSelect({ optionsFilter: ['DELETE_TASK'] });
-    await SelectUtil.assertOptionsCount(3, 'Responsible');
+    await SelectUtil.assertOptionsCount(3, { label: 'Responsible' });
   });
 
   test('responsible select will render select for role with default option', async () => {
     renderSelect({ type: 'ROLE' });
-    await SelectUtil.assertValue('Role', 'Responsible');
-    await SelectUtil.assertValue('Everybody', 'Role');
+    await SelectUtil.assertValue('Role', { label: 'Responsible' });
+    await SelectUtil.assertValue('Everybody', { index: 1 });
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
   test('responsible select will render select for role', async () => {
     renderSelect({ type: 'ROLE', activator: 'Teamleader' });
-    await SelectUtil.assertValue('Role', 'Responsible');
-    await SelectUtil.assertValue('Teamleader', 'Role');
+    await SelectUtil.assertValue('Role', { label: 'Responsible' });
+    await SelectUtil.assertValue('Teamleader', { index: 1 });
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
   test('responsible select will render input for role attr option', async () => {
     renderSelect({ type: 'ROLE_FROM_ATTRIBUTE', activator: 'role activator' });
-    await SelectUtil.assertValue('Role from Attr', 'Responsible');
+    await SelectUtil.assertValue('Role from Attr', { label: 'Responsible' });
     expect(screen.getByRole('textbox')).toHaveValue('role activator');
   });
 
   test('responsible select will render input for user attr option', async () => {
     renderSelect({ type: 'USER_FROM_ATTRIBUTE', activator: 'user activator' });
-    await SelectUtil.assertValue('User from Attr', 'Responsible');
+    await SelectUtil.assertValue('User from Attr', { label: 'Responsible' });
     expect(screen.getByRole('textbox')).toHaveValue('user activator');
   });
 
   test('responsible select will render nothing for delete option', async () => {
     renderSelect({ type: 'DELETE_TASK' });
-    await SelectUtil.assertValue('Nobody & delete', 'Responsible');
+    await SelectUtil.assertValue('Nobody & delete', { label: 'Responsible' });
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 });

--- a/packages/editor/src/components/widgets/combobox/Combobox.css
+++ b/packages/editor/src/components/widgets/combobox/Combobox.css
@@ -1,6 +1,3 @@
-.combobox {
-  position: relative;
-}
 .combobox-input {
   display: flex;
 }
@@ -19,7 +16,6 @@
 }
 .combobox-menu {
   overflow: auto;
-  width: calc(100% - 24px);
   max-height: 20rem;
   position: absolute;
   list-style: none;
@@ -27,10 +23,9 @@
   text-align: start;
   background-color: var(--input-bg);
   padding: 0;
-  margin: 2px;
+  margin: 0px;
   z-index: 10;
   box-shadow: var(--editor-shadow);
-  top: calc(1em + 0.5rem + 30px);
 }
 .combobox-menu-entry {
   padding: 0.5rem;

--- a/packages/editor/src/components/widgets/combobox/Combobox.test.tsx
+++ b/packages/editor/src/components/widgets/combobox/Combobox.test.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import { Message } from '../../props/message';
 import Combobox, { ComboboxItem } from './Combobox';
 import { render, screen, userEvent } from 'test-utils';
 
@@ -10,19 +9,16 @@ describe('Combobox', () => {
       itemFilter?: (item: ComboboxItem, input?: string) => boolean;
       comboboxItem?: (item: ComboboxItem) => ReactNode;
       onChange?: (change: string) => void;
-      message?: Message;
     } = {}
   ) {
     const items: ComboboxItem[] = [{ value: 'test' }, { value: 'bla' }];
     render(
       <Combobox
-        label='Combobox'
         items={items}
         itemFilter={options.itemFilter}
         comboboxItem={options.comboboxItem ? options.comboboxItem : item => <span>{item.value}</span>}
         value={value}
         onChange={options.onChange ? options.onChange : () => {}}
-        message={options.message}
       />
     );
   }
@@ -43,9 +39,8 @@ describe('Combobox', () => {
 
   test('combobox will render', async () => {
     renderCombobox('test');
-    const combobox = screen.getByRole('combobox', { name: 'Combobox' });
+    const combobox = screen.getByRole('combobox');
     expect(combobox).toHaveValue('test');
-    expect(combobox).toHaveAttribute('placeholder', 'Select Combobox');
     const button = screen.getByRole('button', { name: 'toggle menu' });
     expect(button).toHaveAttribute('aria-expanded', 'false');
   });
@@ -74,7 +69,7 @@ describe('Combobox', () => {
     const item = screen.getByRole('option', { name: 'bla' });
     await userEvent.click(item);
     assertMenuContent();
-    const combobox = screen.getByRole('combobox', { name: 'Combobox' });
+    const combobox = screen.getByRole('combobox');
     expect(combobox).toHaveValue('bla');
     expect(data).toEqual('bla');
   });
@@ -82,7 +77,7 @@ describe('Combobox', () => {
   test('combobox will not update on invalid input', async () => {
     let data = 'test';
     renderCombobox(data, { onChange: (change: string) => (data = change) });
-    const combobox = screen.getByRole('combobox', { name: 'Combobox' });
+    const combobox = screen.getByRole('combobox');
     await userEvent.type(combobox, '123');
     expect(combobox).toHaveValue('test123');
     expect(data).toEqual('test');
@@ -91,7 +86,7 @@ describe('Combobox', () => {
   test('combobox will update on input change', async () => {
     let data = 'test';
     renderCombobox(data, { onChange: (change: string) => (data = change) });
-    const combobox = screen.getByRole('combobox', { name: 'Combobox' });
+    const combobox = screen.getByRole('combobox');
     await userEvent.clear(combobox);
     await userEvent.type(combobox, 'la');
     await userEvent.keyboard('[ArrowDown]');
@@ -109,7 +104,7 @@ describe('Combobox', () => {
       return item.value.startsWith(input);
     };
     renderCombobox('test', { itemFilter: itemFilter });
-    const combobox = screen.getByRole('combobox', { name: 'Combobox' });
+    const combobox = screen.getByRole('combobox');
     await userEvent.clear(combobox);
     await userEvent.type(combobox, 'la');
     assertMenuContent();
@@ -118,24 +113,12 @@ describe('Combobox', () => {
     assertMenuContent(['bla']);
   });
 
-  test('combobox will render message', async () => {
-    renderCombobox('test', { message: { message: 'this is a message', severity: 'ERROR' } });
-    expect(screen.getByText('this is a message')).toHaveClass('fieldset-message', 'fieldset-error');
-  });
-
   test('combobox support readonly mode', async () => {
-    render(
-      <Combobox
-        label='Combobox'
-        items={[{ value: 'test' }]}
-        comboboxItem={item => <span>{item.value}</span>}
-        value={'test'}
-        onChange={() => {}}
-      />,
-      { wrapperProps: { editor: { readonly: true } } }
-    );
+    render(<Combobox items={[{ value: 'test' }]} comboboxItem={item => <span>{item.value}</span>} value={'test'} onChange={() => {}} />, {
+      wrapperProps: { editor: { readonly: true } }
+    });
 
-    expect(screen.getByRole('combobox', { name: 'Combobox' })).toBeDisabled();
+    expect(screen.getByRole('combobox')).toBeDisabled();
     expect(screen.getByRole('button', { name: 'toggle menu' })).toBeDisabled();
   });
 });

--- a/packages/editor/src/components/widgets/combobox/Combobox.tsx
+++ b/packages/editor/src/components/widgets/combobox/Combobox.tsx
@@ -1,25 +1,26 @@
 import { useCombobox } from 'downshift';
 import { memo, ReactNode, useEffect, useState } from 'react';
 import './Combobox.css';
-import { Message } from '../../props/message';
 import { useReadonly } from '../../../context';
 import { IvyIcons } from '@axonivy/editor-icons';
 import IvyIcon from '../IvyIcon';
-import { Fieldset } from '../fieldset';
 
 export interface ComboboxItem {
   value: string;
 }
 
-const Combobox = (props: {
-  label: string;
+export type ComboboxInputProps = { id: string; 'aria-labelledby': string };
+
+export type ComboboxProps = {
   items: ComboboxItem[];
   itemFilter?: (item: ComboboxItem, input?: string) => boolean;
   comboboxItem: (item: ComboboxItem) => ReactNode;
   value: string;
   onChange: (change: string) => void;
-  message?: Message;
-}) => {
+  inputProps?: ComboboxInputProps;
+};
+
+const Combobox = (props: ComboboxProps) => {
   const itemFilter = props.itemFilter
     ? props.itemFilter
     : (item: ComboboxItem, input?: string) => {
@@ -32,36 +33,33 @@ const Combobox = (props: {
 
   const [items, setItems] = useState(props.items);
   useEffect(() => setItems(props.items), [props.items]);
-  const { isOpen, getToggleButtonProps, getLabelProps, getMenuProps, getInputProps, highlightedIndex, getItemProps, selectedItem } =
-    useCombobox({
-      onSelectedItemChange(change) {
-        setItems(props.items);
-        props.onChange(change.inputValue ?? '');
-      },
-      onInputValueChange(change) {
-        if (change.type !== '__item_click__') {
-          setItems(props.items.filter(item => itemFilter(item, change.inputValue)));
-        }
-      },
-      items,
-      itemToString(item) {
-        return item?.value ?? '';
-      },
-      initialSelectedItem: { value: props.value }
-    });
+  const { isOpen, getToggleButtonProps, getMenuProps, getInputProps, highlightedIndex, getItemProps, selectedItem } = useCombobox({
+    onSelectedItemChange(change) {
+      setItems(props.items);
+      props.onChange(change.inputValue ?? '');
+    },
+    onInputValueChange(change) {
+      if (change.type !== '__item_click__') {
+        setItems(props.items.filter(item => itemFilter(item, change.inputValue)));
+      }
+    },
+    items,
+    itemToString(item) {
+      return item?.value ?? '';
+    },
+    initialSelectedItem: { value: props.value }
+  });
 
   const readonly = useReadonly();
 
   return (
     <div className='combobox'>
-      <Fieldset label={props.label} {...getLabelProps()} message={props.message}>
-        <div className='combobox-input'>
-          <input id='input' placeholder={`Select ${props.label}`} className='input' {...getInputProps()} disabled={readonly} />
-          <button aria-label='toggle menu' className='combobox-button button' {...getToggleButtonProps()} disabled={readonly}>
-            <IvyIcon icon={IvyIcons.AngleDown} />
-          </button>
-        </div>
-      </Fieldset>
+      <div className='combobox-input'>
+        <input className='input' {...getInputProps()} {...props.inputProps} disabled={readonly} />
+        <button aria-label='toggle menu' className='combobox-button button' {...getToggleButtonProps()} disabled={readonly}>
+          <IvyIcon icon={IvyIcons.AngleDown} />
+        </button>
+      </div>
       <ul {...getMenuProps()} className='combobox-menu'>
         {isOpen &&
           items.map((item, index) => (

--- a/packages/editor/src/components/widgets/fieldset/Fieldset.test.tsx
+++ b/packages/editor/src/components/widgets/fieldset/Fieldset.test.tsx
@@ -1,6 +1,6 @@
 import { Message } from '../../props/message';
-import Fieldset, { FieldsetData } from './Fieldset';
-import { render, screen, userEvent } from 'test-utils';
+import Fieldset, { FieldsetData, useFieldset } from './Fieldset';
+import { render, renderHook, screen, userEvent } from 'test-utils';
 import { FieldsetControl } from './Fieldset';
 import { IvyIcons } from '@axonivy/editor-icons';
 
@@ -57,4 +57,25 @@ describe('Fieldset', () => {
     const btn2 = screen.getByRole('button', { name: 'Btn2' });
     expect(btn2).toHaveAttribute('data-state', 'active');
   });
+
+  test('useFieldset hook', () => {
+    const { result: fieldset1 } = renderHook(() => useFieldset());
+    const { result: fieldset2 } = renderHook(() => useFieldset());
+    expect(fieldset1).not.toEqual(fieldset2);
+    expect(fieldset1.current).toEqual(fieldsetHookReturnValue(0));
+    expect(fieldset2.current).toEqual(fieldsetHookReturnValue(1));
+  });
+
+  function fieldsetHookReturnValue(index: number) {
+    return {
+      inputProps: {
+        'aria-labelledby': `fieldset-${index}-label`,
+        id: `fieldset-${index}-input`
+      },
+      labelProps: {
+        htmlFor: `fieldset-${index}-input`,
+        id: `fieldset-${index}-label`
+      }
+    };
+  }
 });

--- a/packages/editor/src/components/widgets/fieldset/Fieldset.tsx
+++ b/packages/editor/src/components/widgets/fieldset/Fieldset.tsx
@@ -1,6 +1,6 @@
 import './Fieldset.css';
 import { Label } from '@radix-ui/react-label';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { IvyIcons } from '@axonivy/editor-icons';
 import Button from '../button/Button';
 import IvyIcon from '../IvyIcon';
@@ -8,6 +8,7 @@ import { Message } from '../../../components/props';
 import { LabelProps } from '@radix-ui/react-label';
 import { deepEqual } from '../../../utils/equals';
 import { Consumer } from '../../../types/lambda';
+import { generateId } from '../../../utils/utils';
 
 export interface FieldsetControl {
   label: string;
@@ -36,15 +37,27 @@ export type FieldsetProps<T> = LabelProps & {
   message?: Message;
 };
 
-const Fieldset = <T,>(props: FieldsetProps<T>) => {
+type UseFieldsetReturnValue = {
+  labelProps: { id: string; htmlFor: string };
+  inputProps: { id: string; 'aria-labelledby': string };
+};
+
+export function useFieldset(): UseFieldsetReturnValue {
+  const id = useMemo(() => `fieldset-${generateId()}`, []);
+  const labelId = `${id}-label`;
+  const inputId = `${id}-input`;
+  return { labelProps: { id: labelId, htmlFor: inputId }, inputProps: { id: inputId, 'aria-labelledby': labelId } };
+}
+
+const Fieldset = <T,>({ label, data, controls, message, children, ...labelProps }: FieldsetProps<T>) => {
   return (
     <div className='fieldset-column'>
       <div className='fieldset-label'>
-        <Label {...props} className={`label ${props.className}`}>
-          {props.label}
+        <Label {...labelProps} className={`label ${labelProps.className}`}>
+          {label}
         </Label>
         <div className='fieldset-controls'>
-          {props.controls?.map((control, index) => (
+          {controls?.map((control, index) => (
             <Button
               icon={control.icon}
               key={index}
@@ -54,21 +67,21 @@ const Fieldset = <T,>(props: FieldsetProps<T>) => {
               data-state={control.active ? 'active' : 'inactive'}
             />
           ))}
-          {props.data && !deepEqual(props.data.data, props.data.initData) && (
+          {data && !deepEqual(data.data, data.initData) && (
             <Button
               icon={IvyIcons.Undo}
               aria-label='Reset'
               className='fieldset-control-button'
-              onClick={() => props.data!.updateData(props.data!.initData)}
+              onClick={() => data!.updateData(data!.initData)}
             />
           )}
         </div>
       </div>
-      {props.children}
-      {props.message && (
-        <div className={`fieldset-message fieldset-${props.message.severity.toString().toLowerCase()}`}>
-          <IvyIcon icon={props.message.severity} />
-          {props.message.message}
+      {children}
+      {message && (
+        <div className={`fieldset-message fieldset-${message.severity.toString().toLowerCase()}`}>
+          <IvyIcon icon={message.severity} />
+          {message.message}
         </div>
       )}
     </div>

--- a/packages/editor/src/components/widgets/input/Textarea.tsx
+++ b/packages/editor/src/components/widgets/input/Textarea.tsx
@@ -7,15 +7,15 @@ export type TextareaProps = Omit<ComponentProps<'textarea'>, 'value' | 'onChange
   data: FieldsetData<string>;
 };
 
-const Textarea = (props: TextareaProps) => {
+const Textarea = ({ data, ...textareaProps }: TextareaProps) => {
   const readonly = useReadonly();
 
   return (
     <textarea
-      {...props}
-      className={`input ${props.className ?? ''}`}
-      value={props.data.data ?? ''}
-      onChange={event => props.data.updateData(event.target.value)}
+      {...textareaProps}
+      className={`input ${textareaProps.className ?? ''}`}
+      value={data.data ?? ''}
+      onChange={event => data.updateData(event.target.value)}
       disabled={readonly}
     />
   );

--- a/packages/editor/src/components/widgets/select/Select.css
+++ b/packages/editor/src/components/widgets/select/Select.css
@@ -1,10 +1,8 @@
 .select {
-  position: relative;
   width: 100%;
 }
 .select-input {
   display: flex;
-  /* width: 100%; */
 }
 .select-button {
   cursor: pointer;
@@ -15,6 +13,7 @@
   background: var(--input-bg);
   display: inline-flex;
   justify-content: space-between;
+  align-items: center;
   gap: var(--size-1);
   width: 100%;
 }
@@ -30,7 +29,6 @@
 }
 .select-menu {
   overflow: auto;
-  width: 100%;
   max-height: 20rem;
   position: absolute;
   list-style: none;
@@ -38,10 +36,9 @@
   text-align: start;
   background-color: var(--input-bg);
   padding: 0;
-  margin: 10px 0 0 0;
+  margin: 0;
   z-index: 10;
   box-shadow: var(--editor-shadow);
-  top: calc(1em + var(--size-2) + 30px);
 }
 .select-menu-entry {
   padding: var(--size-2);

--- a/packages/editor/src/components/widgets/select/Select.test.tsx
+++ b/packages/editor/src/components/widgets/select/Select.test.tsx
@@ -14,15 +14,10 @@ describe('Select', () => {
   } {
     let value = items[0];
     userEvent.setup();
-    const view = render(
-      <Select label='test select' items={items} value={items[0]} onChange={(change: SelectItem) => (value = change)} message={message} />
-    );
+    const view = render(<Select items={items} value={items[0]} onChange={(change: SelectItem) => (value = change)} />);
     return {
       data: () => value,
-      rerender: () =>
-        view.rerender(
-          <Select label='test select' items={items} value={value} onChange={(change: SelectItem) => (value = change)} message={message} />
-        )
+      rerender: () => view.rerender(<Select items={items} value={value} onChange={(change: SelectItem) => (value = change)} />)
     };
   }
 
@@ -61,11 +56,6 @@ describe('Select', () => {
     expect(view.data().value).toEqual('bla');
   });
 
-  test('select will render message', async () => {
-    renderSelect({ message: 'this is a test message', severity: 'ERROR' });
-    expect(screen.getByText('this is a test message')).toHaveClass('fieldset-error');
-  });
-
   test('select can be handled with keyboard', async () => {
     const view = renderSelect();
     const select = screen.getByRole('combobox');
@@ -99,7 +89,7 @@ describe('Select', () => {
   });
 
   test('select support readonly mode', () => {
-    render(<Select label='readonly select' items={items} value={items[0]} onChange={() => {}} />, {
+    render(<Select items={items} value={items[0]} onChange={() => {}} />, {
       wrapperProps: { editor: { readonly: true } }
     });
     expect(screen.getByRole('combobox')).toBeDisabled();

--- a/packages/editor/src/components/widgets/select/Select.tsx
+++ b/packages/editor/src/components/widgets/select/Select.tsx
@@ -1,9 +1,7 @@
 import './Select.css';
 import { useSelect } from 'downshift';
-import { memo, ReactNode, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useReadonly } from '../../../context';
-import { Message } from '../../../components/props';
-import { Fieldset } from '../fieldset';
 import { IvyIcons } from '@axonivy/editor-icons';
 import IvyIcon from '../IvyIcon';
 
@@ -14,20 +12,22 @@ export type SelectItem = {
 
 export const EMPTY_SELECT_ITEM: SelectItem = { label: '', value: '' };
 
-const Select = (props: {
-  label: string;
+export type SelectInputProps = { id: string; 'aria-labelledby': string };
+
+export type SelectProps = {
   value?: SelectItem;
   onChange: (value: SelectItem) => void;
   items: SelectItem[];
-  message?: Message;
-  children?: ReactNode;
-}) => {
+  inputProps?: SelectInputProps;
+};
+
+const Select = (props: SelectProps) => {
   const [items, setItems] = useState(props.items);
   useEffect(() => setItems(props.items), [props.items]);
   const [selectedItem, setSelectedItem] = useState(props.value ?? EMPTY_SELECT_ITEM);
   useEffect(() => setSelectedItem(props.value ?? EMPTY_SELECT_ITEM), [props.value]);
 
-  const { isOpen, getToggleButtonProps, getLabelProps, getMenuProps, highlightedIndex, getItemProps } = useSelect<SelectItem>({
+  const { isOpen, getToggleButtonProps, getMenuProps, highlightedIndex, getItemProps } = useSelect<SelectItem>({
     selectedItem: selectedItem,
     items: items,
     onSelectedItemChange: change => change.selectedItem && props.onChange(change.selectedItem)
@@ -36,15 +36,19 @@ const Select = (props: {
 
   return (
     <div className='select'>
-      <Fieldset label={props.label} {...getLabelProps()} message={props.message}>
-        <div className='select-input'>
-          <button aria-label='toggle menu' className='select-button' type='button' {...getToggleButtonProps()} disabled={readonly}>
-            <span>{selectedItem ? selectedItem.label : ''}</span>
-            <IvyIcon icon={IvyIcons.AngleDown} />
-          </button>
-          {props.children}
-        </div>
-      </Fieldset>
+      <div className='select-input'>
+        <button
+          aria-label='toggle menu'
+          className='select-button'
+          type='button'
+          {...getToggleButtonProps()}
+          {...props.inputProps}
+          disabled={readonly}
+        >
+          <span>{selectedItem ? selectedItem.label : ''}</span>
+          <IvyIcon icon={IvyIcons.AngleDown} />
+        </button>
+      </div>
       <ul {...getMenuProps()} className='select-menu'>
         {isOpen &&
           props.items.map((item, index) => (

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -2,8 +2,8 @@ import './EditableCell.css';
 import './CodeEditorCell.css';
 import { CellContext, RowData } from '@tanstack/react-table';
 import { useEffect, useState } from 'react';
-import { useReadonly } from '../../../../context';
 import { CodeEditor } from '../../code-editor';
+import { Input } from '../../input';
 
 declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -29,7 +29,6 @@ export function CodeEditorCell<TData>({
   useEffect(() => {
     setValue(initialValue);
   }, [initialValue]);
-  const readonly = useReadonly();
 
   return (
     <>
@@ -44,13 +43,7 @@ export function CodeEditorCell<TData>({
           />
         </div>
       ) : (
-        <input
-          className='input'
-          value={value as string}
-          onChange={e => setValue(e.target.value)}
-          onClick={() => setIsActive(true)}
-          disabled={readonly}
-        />
+        <Input value={value as string} onChange={change => setValue(change)} onClick={() => setIsActive(true)} />
       )}
     </>
   );

--- a/packages/editor/src/components/widgets/table/cell/EditableCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/EditableCell.tsx
@@ -1,7 +1,7 @@
 import './EditableCell.css';
 import { CellContext, RowData } from '@tanstack/react-table';
 import { useEffect, useState } from 'react';
-import { useReadonly } from '../../../../context';
+import { Input } from '../../input';
 
 declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -19,7 +19,6 @@ export function EditableCell<TData>(props: { cell: CellContext<TData, unknown> }
   useEffect(() => {
     setValue(initialValue);
   }, [initialValue]);
-  const readonly = useReadonly();
 
-  return <input className='input' value={value as string} onChange={e => setValue(e.target.value)} onBlur={onBlur} disabled={readonly} />;
+  return <Input value={value as string} onChange={change => setValue(change)} onBlur={onBlur} />;
 }

--- a/packages/editor/src/components/widgets/table/cell/SelectCell.css
+++ b/packages/editor/src/components/widgets/table/cell/SelectCell.css
@@ -1,6 +1,3 @@
-.table-cell .label {
-  display: none;
-}
 .table-cell .select-button {
   background-color: var(--table-row-bg);
   padding: 5px;

--- a/packages/editor/src/components/widgets/table/cell/SelectCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/SelectCell.tsx
@@ -14,5 +14,5 @@ export function SelectCell<TData>(props: { cell: CellContext<TData, unknown>; it
   const setValue = (item: SelectItem) => {
     props.cell.table.options.meta?.updateData(props.cell.row.id, props.cell.column.id, item.value);
   };
-  return <Select label='' items={props.items} value={{ label: value, value: value }} onChange={setValue} />;
+  return <Select items={props.items} value={{ label: value, value: value }} onChange={setValue} />;
 }

--- a/packages/editor/src/components/widgets/tag/Tags.tsx
+++ b/packages/editor/src/components/widgets/tag/Tags.tsx
@@ -6,6 +6,7 @@ import { useReadonly } from '../../../context';
 import IvyIcon from '../IvyIcon';
 import { IvyIcons } from '@axonivy/editor-icons';
 import { Fieldset } from '../fieldset';
+import { Input } from '../input';
 
 const Tags = (props: { tags: string[]; onChange: (tags: string[]) => void }) => {
   const [newTag, setNewTag] = useState('');
@@ -62,7 +63,7 @@ const Tags = (props: { tags: string[]; onChange: (tags: string[]) => void }) => 
         <Popover.Portal container={(document.querySelector('.editor-root') as HTMLElement) ?? document.querySelector('body')}>
           <Popover.Content className='popover-content' sideOffset={5}>
             <Fieldset label='New Tag' htmlFor='tag-input'>
-              <input className='input' id='tag-input' value={newTag} onChange={e => setNewTag(e.target.value)} {...keyboardProps} />
+              <Input id='tag-input' value={newTag} {...keyboardProps} onChange={change => setNewTag(change)} />
             </Fieldset>
             <Popover.Close className='popover-close' aria-label='Close'>
               <IvyIcon icon={IvyIcons.Add} rotate={45} />

--- a/packages/editor/src/test-utils/select-utils.tsx
+++ b/packages/editor/src/test-utils/select-utils.tsx
@@ -1,25 +1,31 @@
 import { screen, userEvent, waitFor } from 'test-utils';
 
+type SelectUtilOptions = {
+  label?: string;
+  index?: number;
+};
+
 export namespace SelectUtil {
-  export function combobox(label?: string) {
-    if (label) {
-      return screen.getByRole('combobox', { name: label });
-    } else {
-      return screen.getByRole('combobox');
+  export function select(options?: SelectUtilOptions) {
+    if (options?.label) {
+      return screen.getByRole('combobox', { name: options.label });
     }
+    if (options?.index) {
+      return screen.getAllByRole('combobox')[options.index];
+    }
+    return screen.getByRole('combobox');
   }
 
-  export async function assertEmpty(label?: string) {
-    await assertValue('', label);
+  export async function assertEmpty(options?: SelectUtilOptions) {
+    await assertValue('', options);
   }
 
-  export async function assertValue(value: string, label?: string) {
-    await waitFor(() => expect(combobox(label)).toHaveTextContent(value));
+  export async function assertValue(value: string, options?: SelectUtilOptions) {
+    await waitFor(() => expect(select(options)).toHaveTextContent(value));
   }
 
-  export async function assertOptionsCount(count: number, label?: string) {
-    const select = combobox(label);
-    await userEvent.click(select);
+  export async function assertOptionsCount(count: number, options?: SelectUtilOptions) {
+    await userEvent.click(select(options));
     expect(screen.getAllByRole('option')).toHaveLength(count);
   }
 }

--- a/packages/editor/src/utils/utils.ts
+++ b/packages/editor/src/utils/utils.ts
@@ -1,0 +1,5 @@
+let idCounter = 0;
+
+export function generateId() {
+  return String(idCounter++);
+}


### PR DESCRIPTION
Widget (like combobox, select) should not longer provide a label itself. The user of a such widget should wrap them into a Fieldset component.

- Add fieldset hook to build label and input props to link them together
- Refactor fieldsets out of combobox and select widgets