### PR TITLE
XIVY-11675 Add own monaco language for ivy macros

### DIFF
--- a/packages/core/src/ivy-script-client.ts
+++ b/packages/core/src/ivy-script-client.ts
@@ -7,7 +7,7 @@ export namespace IvyScriptLanguage {
     const connection = await ConnectionUtil.createWebSocketConnection(url);
     const client = new MonacoLanguageClient({
       name: 'IvyScript Language Client',
-      clientOptions: { documentSelector: ['ivyScript'] },
+      clientOptions: { documentSelector: [{ language: 'ivyScript' }, { language: 'ivyMacro' }] },
       connectionProvider: { get: async () => connection }
     });
     client.start();

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
@@ -31,7 +31,7 @@ const CodeEditor = ({ value, onChange, location, macro, onMountFuncs, options, i
         className='code-input'
         defaultValue={value}
         value={value}
-        defaultLanguage={'ivyScript'}
+        defaultLanguage={macro ? 'ivyMacro' : 'ivyScript'}
         defaultPath={`${macro ? 'macro' : 'ivyScript'}/${editorContext.pid}?location=${location ?? ''}`}
         options={monacoOptions}
         theme={MonacoEditorUtil.DEFAULT_THEME_NAME}

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
@@ -24,6 +24,7 @@ const CodeEditor = ({ value, onChange, location, macro, onMountFuncs, options, i
 
   const monacoOptions = options ?? MONACO_OPTIONS;
   monacoOptions.readOnly = editorContext.readonly;
+  const language = macro ? 'ivyMacro' : 'ivyScript';
 
   return (
     <div {...(id ? { id } : {})} className='code-editor'>
@@ -31,8 +32,8 @@ const CodeEditor = ({ value, onChange, location, macro, onMountFuncs, options, i
         className='code-input'
         defaultValue={value}
         value={value}
-        defaultLanguage={macro ? 'ivyMacro' : 'ivyScript'}
-        defaultPath={`${macro ? 'macro' : 'ivyScript'}/${editorContext.pid}?location=${location ?? ''}`}
+        defaultLanguage={language}
+        defaultPath={`${language}/${editorContext.pid}?location=${location ?? ''}`}
         options={monacoOptions}
         theme={MonacoEditorUtil.DEFAULT_THEME_NAME}
         onChange={code => onChange(code ?? '')}

--- a/packages/editor/src/monaco/ivy-macro-language.ts
+++ b/packages/editor/src/monaco/ivy-macro-language.ts
@@ -1,6 +1,6 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
-export const ivyScriptLang: monaco.languages.IMonarchLanguage = {
+export const ivyMacroLang: monaco.languages.IMonarchLanguage = {
   defaultToken: '',
   tokenPostfix: '.ivyscript',
   keywords: [
@@ -82,6 +82,7 @@ export const ivyScriptLang: monaco.languages.IMonarchLanguage = {
       ],
       { include: '@whitespace' },
       [/[{}()[\]]/, '@brackets'],
+      [/<%=?|%>/, 'tag'],
       [/[<>](?!@symbols)/, '@brackets'],
       [
         /@symbols/,
@@ -125,7 +126,7 @@ export const ivyScriptLang: monaco.languages.IMonarchLanguage = {
   }
 };
 
-export const ivyScriptConf: monaco.languages.LanguageConfiguration = {
+export const ivyMacroConf: monaco.languages.LanguageConfiguration = {
   wordPattern: /(-?\d*\.\d\w*)|([^`~!#%^&*()\-=+[{\]}\\|;:'",.<>/?\s]+)/g,
   comments: {
     lineComment: '//',
@@ -141,7 +142,8 @@ export const ivyScriptConf: monaco.languages.LanguageConfiguration = {
     { open: '[', close: ']' },
     { open: '(', close: ')' },
     { open: '"', close: '"' },
-    { open: "'", close: "'" }
+    { open: "'", close: "'" },
+    { open: '<%', close: '%>' }
   ],
   surroundingPairs: [
     { open: '{', close: '}' },

--- a/packages/editor/src/monaco/monaco-editor-util.ts
+++ b/packages/editor/src/monaco/monaco-editor-util.ts
@@ -2,6 +2,7 @@ import { loader, Monaco } from '@monaco-editor/react';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { ThemeMode } from '../context/useTheme';
 import { ivyScriptConf, ivyScriptLang } from './ivy-script-language';
+import { ivyMacroConf, ivyMacroLang } from './ivy-macro-language';
 
 export const MONACO_OPTIONS: monaco.editor.IStandaloneEditorConstructionOptions = {
   glyphMargin: false,
@@ -56,8 +57,15 @@ export namespace MonacoEditorUtil {
         extensions: ['.ivyScript', '.ivyScript'],
         aliases: ['IvyScript', 'ivyScript']
       });
+      monaco.languages.register({
+        id: 'ivyMacro',
+        extensions: ['.ivyMacro', '.ivyMacro'],
+        aliases: []
+      });
       monaco.languages.setLanguageConfiguration('ivyScript', ivyScriptConf);
       monaco.languages.setMonarchTokensProvider('ivyScript', ivyScriptLang);
+      monaco.languages.setLanguageConfiguration('ivyMacro', ivyMacroConf);
+      monaco.languages.setMonarchTokensProvider('ivyMacro', ivyMacroLang);
 
       monaco.editor.defineTheme(DEFAULT_THEME_NAME, themeData(theme));
       return monaco;


### PR DESCRIPTION
Add own Monaco language for ivy macros and provide highlighting of <% and %>

Also support that %> is auto inserted if <% is inserted

ivyScript and ivyMacro language is served by the same LSP