### PR TITLE
XIVY-11675 Small review fixes

### DIFF
--- a/integrations/standalone/tests/utils/code-editor-util.ts
+++ b/integrations/standalone/tests/utils/code-editor-util.ts
@@ -22,7 +22,7 @@ export namespace CodeEditorUtil {
   }
 
   export async function triggerContentAssist(page: Page) {
-    triggerContentAssistWithLocator(page, page.getByRole('code').nth(0));
+    await triggerContentAssistWithLocator(page, page.getByRole('code').nth(0));
   }
 
   export async function triggerContentAssistWithLocator(page: Page, locator: Locator) {

--- a/packages/editor/src/components/browser/AttributeBrowser.tsx
+++ b/packages/editor/src/components/browser/AttributeBrowser.tsx
@@ -135,7 +135,7 @@ const AttributeBrowser = ({ value, onChange, location }: { value: string; onChan
         </thead>
         <tbody>
           {table.getRowModel().rows.map(row => (
-            <SelectRow row={row}>
+            <SelectRow key={row.id} row={row}>
               {row.getVisibleCells().map(cell => (
                 <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
               ))}

--- a/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
@@ -10,7 +10,8 @@ const MacroArea = (props: CodeEditorAreaProps) => {
   const { setEditor, modifyEditor } = useModifyEditor();
 
   return (
-    <div className='script-area' {...focusWithinProps}>
+    // tabIndex is needed for safari to catch the focus when click on browser button
+    <div className='script-area' {...focusWithinProps} tabIndex={1}>
       {isFocusWithin || browser.open ? (
         <>
           <ResizableCodeEditor {...props} onMountFuncs={[setEditor, monacoAutoFocus]} macro={true} />

--- a/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
@@ -10,7 +10,8 @@ const MacroInput = (props: CodeEditorInputProps) => {
   const { setEditor, modifyEditor } = useModifyEditor();
 
   return (
-    <div className='script-input' {...focusWithinProps}>
+    // tabIndex is needed for safari to catch the focus when click on browser button
+    <div className='script-input' {...focusWithinProps} tabIndex={1}>
       {isFocusWithin || browser.open ? (
         <>
           <SingleLineCodeEditor {...props} macro={true} onMountFuncs={[setEditor]} />

--- a/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
@@ -10,7 +10,8 @@ const ScriptInput = (props: CodeEditorInputProps) => {
   const { setEditor, modifyEditor } = useModifyEditor();
 
   return (
-    <div className='script-input' {...focusWithinProps}>
+    // tabIndex is needed for safari to catch the focus when click on browser button
+    <div className='script-input' {...focusWithinProps} tabIndex={1}>
       {isFocusWithin || browser.open ? (
         <>
           <SingleLineCodeEditor {...props} onMountFuncs={[setEditor]} />

--- a/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
@@ -4,9 +4,15 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import CodeEditor, { CodeEditorProps } from './CodeEditor';
 import { monacoAutoFocus } from './useCodeEditor';
 
-export type CodeEditorInputProps = Omit<CodeEditorProps, 'macro' | 'options' | 'onMount' | 'height' | 'onMountFuncs'>;
+type EditorOptions = {
+  editorOptions?: {
+    fixedOverflowWidgets?: boolean;
+  };
+};
 
-const SingleLineCodeEditor = ({ onChange, onMountFuncs, ...props }: CodeEditorProps) => {
+export type CodeEditorInputProps = Omit<CodeEditorProps, 'macro' | 'options' | 'onMount' | 'height' | 'onMountFuncs'> & EditorOptions;
+
+const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, ...props }: CodeEditorProps & EditorOptions) => {
   const mountFuncs = onMountFuncs ? onMountFuncs : [];
   const singleLineMountFuncs = (editor: monaco.editor.IStandaloneCodeEditor) => {
     editor.createContextKey('singleLine', true);
@@ -47,7 +53,7 @@ const SingleLineCodeEditor = ({ onChange, onMountFuncs, ...props }: CodeEditorPr
     <CodeEditor
       height={40}
       onChange={onCodeChange}
-      options={SINGLE_LINE_MONACO_OPTIONS}
+      options={editorOptions ? { ...SINGLE_LINE_MONACO_OPTIONS, ...editorOptions } : SINGLE_LINE_MONACO_OPTIONS}
       onMountFuncs={[...mountFuncs, monacoAutoFocus, singleLineMountFuncs]}
       {...props}
     />

--- a/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
+++ b/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
@@ -4,7 +4,7 @@ import { useFocusWithin } from 'react-aria';
 
 export const useCodeEditorOnFocus = () => {
   const [isFocusWithin, setFocusWithin] = useState(false);
-  let { focusWithinProps } = useFocusWithin({ onFocusWithinChange: isFocusWithin => setFocusWithin(isFocusWithin) });
+  let { focusWithinProps } = useFocusWithin({ onFocusWithinChange: setFocusWithin });
   return { isFocusWithin, focusWithinProps };
 };
 

--- a/packages/editor/src/components/widgets/collapsible/CollapsiblePart.css
+++ b/packages/editor/src/components/widgets/collapsible/CollapsiblePart.css
@@ -21,7 +21,7 @@
   margin-top: var(--size-1);
   display: flex;
   flex-direction: column;
-  gap: var(--size-4);
+  gap: var(--size-3);
 }
 .collapsible-root .collapsible-content[data-state='open'] {
   animation: collapsableSlideDown 200ms cubic-bezier(0.87, 0, 0.13, 1);

--- a/packages/editor/src/components/widgets/table/cell/ScriptCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/ScriptCell.tsx
@@ -53,6 +53,7 @@ export function ScriptCell<TData>({ cell, context }: ScriptCellProps<TData>) {
                   value={value as string}
                   onChange={setValue}
                   location={`${context.location}&type=${context.type}`}
+                  editorOptions={{ fixedOverflowWidgets: false }}
                   {...codeFieldset.inputProps}
                 />
               </Fieldset>

--- a/packages/editor/src/monaco/monaco-editor-util.ts
+++ b/packages/editor/src/monaco/monaco-editor-util.ts
@@ -38,12 +38,9 @@ export const SINGLE_LINE_MONACO_OPTIONS: monaco.editor.IStandaloneEditorConstruc
     autoFindInSelection: 'never',
     seedSearchStringFromSelection: 'never'
   },
-  // wordBasedSuggestions: false,
   links: false,
   renderLineHighlight: 'none',
-  contextmenu: false,
-  // roundedSelection: false,
-  fixedOverflowWidgets: true
+  contextmenu: false
 };
 
 export namespace MonacoEditorUtil {


### PR DESCRIPTION
- Fix suggestion widget position
  - Normal monaco's need to have this `fixedOverflowWidgets` option, but not the one in the mapping tree
- Fix Safari loose focus by clicking on the attribute browser
   Looks like Safari is the next IE... 🤮
   https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus
- Fix react warning about missing key attribute in attribute browser
- Fix css gap in collapsable