### PR TITLE
XIVY-11485 Script types

### DIFF
--- a/packages/editor/src/components/parts/condition/ConditionTable.tsx
+++ b/packages/editor/src/components/parts/condition/ConditionTable.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { Condition } from './condition';
 import { CellContext, ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { IvyIcons } from '@axonivy/editor-icons';
+import { IVY_SCRIPT_TYPES } from '@axonivy/inscription-protocol';
 
 const ConditionTypeCell = ({ condition }: { condition: Condition }) => {
   if (condition.target) {
@@ -13,7 +14,7 @@ const ConditionTypeCell = ({ condition }: { condition: Condition }) => {
 
 const ConditionExpressionCell = ({ cell, removeCell }: { cell: CellContext<Condition, unknown>; removeCell: (id: string) => void }) => {
   if (cell.row.original.target) {
-    return <ScriptCell cell={cell} type='Boolean' />;
+    return <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.BOOLEAN} />;
   }
   return (
     <span style={{ display: 'flex' }}>

--- a/packages/editor/src/components/parts/task/expiry/ExpiryPart.tsx
+++ b/packages/editor/src/components/parts/task/expiry/ExpiryPart.tsx
@@ -4,6 +4,7 @@ import ErrorSelect from './ErrorSelect';
 import PrioritySelect from './../priority/PrioritySelect';
 import ResponsibleSelect from './../responsible/ResponsibleSelect';
 import { useExpiryData } from './useExpiryData';
+import { IVY_SCRIPT_TYPES } from '@axonivy/inscription-protocol';
 
 const ExpiryPart = () => {
   const { expiry, update, updateResponsible, updatePriority } = useExpiryData();
@@ -16,7 +17,7 @@ const ExpiryPart = () => {
         <ScriptInput
           value={expiry.timeout}
           onChange={change => update('timeout', change)}
-          type='Duration'
+          type={IVY_SCRIPT_TYPES.DURATION}
           {...timeoutFieldset.inputProps}
         />
       </PathFieldset>

--- a/packages/editor/src/components/parts/task/options/TaskListPart.tsx
+++ b/packages/editor/src/components/parts/task/options/TaskListPart.tsx
@@ -1,3 +1,4 @@
+import { IVY_SCRIPT_TYPES } from '@axonivy/inscription-protocol';
 import { Checkbox, ScriptInput, useFieldset } from '../../../widgets';
 import { PathCollapsible, ValidationFieldset } from '../../common';
 import { useTaskData } from '../useTaskData';
@@ -10,7 +11,12 @@ const TaskListPart = () => {
     <PathCollapsible label='Options' defaultOpen={task.skipTasklist} path='delay'>
       <Checkbox label='Skip Tasklist' value={task.skipTasklist} onChange={change => update('skipTasklist', change)} />
       <ValidationFieldset label='Delay' {...delayFieldset.labelProps}>
-        <ScriptInput value={task.delay} onChange={change => update('delay', change)} {...delayFieldset.inputProps} type='Duration' />
+        <ScriptInput
+          value={task.delay}
+          onChange={change => update('delay', change)}
+          {...delayFieldset.inputProps}
+          type={IVY_SCRIPT_TYPES.DURATION}
+        />
       </ValidationFieldset>
     </PathCollapsible>
   );

--- a/packages/editor/src/components/parts/task/priority/PrioritySelect.tsx
+++ b/packages/editor/src/components/parts/task/priority/PrioritySelect.tsx
@@ -1,6 +1,6 @@
 import './PrioritySelect.css';
 import { useMemo } from 'react';
-import { WfPriority, WfLevel, PRIORITY_LEVEL, WfTask } from '@axonivy/inscription-protocol';
+import { WfPriority, WfLevel, PRIORITY_LEVEL, WfTask, IVY_SCRIPT_TYPES } from '@axonivy/inscription-protocol';
 import { ScriptInput, Select, SelectItem, useFieldset } from '../../../../components/widgets';
 import { DataUpdater } from '../../../../types/lambda';
 import { PathFieldset } from '../../common';
@@ -28,7 +28,7 @@ const PrioritySelect = ({ priority, updatePriority }: { priority?: WfPriority; u
           inputProps={selectFieldset.inputProps}
         />
         {(selectedLevel.value as WfLevel) === 'SCRIPT' && (
-          <ScriptInput type='Integer' value={priority?.script ?? ''} onChange={change => updatePriority('script', change)} />
+          <ScriptInput type={IVY_SCRIPT_TYPES.INT} value={priority?.script ?? ''} onChange={change => updatePriority('script', change)} />
         )}
       </div>
     </PathFieldset>

--- a/packages/editor/src/components/parts/task/responsible/ResponsibleSelect.tsx
+++ b/packages/editor/src/components/parts/task/responsible/ResponsibleSelect.tsx
@@ -1,6 +1,6 @@
 import './ResponsibleSelect.css';
 import { useEffect, useMemo, useState } from 'react';
-import { WfActivator, WfActivatorType, RESPONSIBLE_TYPE, WfTask } from '@axonivy/inscription-protocol';
+import { WfActivator, WfActivatorType, RESPONSIBLE_TYPE, WfTask, IVY_SCRIPT_TYPES } from '@axonivy/inscription-protocol';
 import { ScriptInput, Select, SelectItem, useFieldset } from '../../../../components/widgets';
 import { useClient, useEditorContext } from '../../../../context';
 import { DataUpdater } from '../../../../types/lambda';
@@ -47,7 +47,7 @@ const ResponsibleActivator = ({ selectedType, ...props }: ActivatorProps) => {
           aria-label='activator'
           value={props.responsible?.activator ?? ''}
           onChange={change => props.updateResponsible('activator', change)}
-          type='String'
+          type={IVY_SCRIPT_TYPES.STRING}
         />
       );
     case 'DELETE_TASK':

--- a/packages/protocol/src/data/workflow-data.ts
+++ b/packages/protocol/src/data/workflow-data.ts
@@ -30,3 +30,10 @@ export const MAIL_TYPE = {
 export const IVY_EXCEPTIONS = {
   mail: 'ivy:error:email'
 } as const;
+
+export const IVY_SCRIPT_TYPES = {
+  ...CUSTOM_FIELD_TYPE,
+  DURATION: 'Duration',
+  BOOLEAN: 'Boolean',
+  INT: 'Integer'
+} as const;


### PR DESCRIPTION
Currently, only the Inscription mask validator knows this.
But our ivyscript lsp currently does know nothing from the input except that evaluated variables.

If we would like to change this, we either need to make the ivyscript lsp more stateful or evaluate the real variable via the location. But if we do the second way, we also need to evaluate the value of a mapping tree, and this is something we definitely know in the frontend.

So I think it does no harm now if we send these types to the backend by now...

Or am I wrong?