### PR TITLE
XIVY-12024 Add macro card text

### DIFF
--- a/integrations/standalone/src/mock/data-mock.ts
+++ b/integrations/standalone/src/mock/data-mock.ts
@@ -30,8 +30,12 @@ export namespace DataMock {
         name: 'user task'
       },
       case: {
-        name: 'case',
-        description: 'desc'
+        name: 'case <%=ivy.cms.co("/Case/name")%> bla <%= in.name %>',
+        description: `<%=ivy.cms.co("/Emails/yourRequestHasBeen")%> 
+blalbalba
+<%=in.amount%> and <%=in.description%> 
+<%=ivy.cms.co("/Dialogs/procurementRequest/forTotal")%> <%=in.totalPrice%> 
+<%=ivy.cms.co("/Dialogs/procurementRequest/currencySymbol")%>`
       },
       output: {
         map: {

--- a/integrations/standalone/tests/integration/parts/case.ts
+++ b/integrations/standalone/tests/integration/parts/case.ts
@@ -1,13 +1,13 @@
 import { Part } from '../../pageobjects/Part';
 import { NewPartTest, PartObject } from './part-tester';
-import { CodeEditor } from '../../pageobjects/CodeEditor';
+import { MacroEditor } from '../../pageobjects/CodeEditor';
 import { Section } from '../../pageobjects/Section';
 import { Table } from '../../pageobjects/Table';
 
 class Case extends PartObject {
-  name: CodeEditor;
-  description: CodeEditor;
-  category: CodeEditor;
+  name: MacroEditor;
+  description: MacroEditor;
+  category: MacroEditor;
   customSection: Section;
   customFields: Table;
 

--- a/integrations/standalone/tests/integration/parts/task.ts
+++ b/integrations/standalone/tests/integration/parts/task.ts
@@ -1,7 +1,7 @@
 import { Accordion } from '../../pageobjects/Accordion';
 import { NewPartTest, PartObject, PartTest } from './part-tester';
 import { Part } from '../../pageobjects/Part';
-import { CodeEditor } from '../../pageobjects/CodeEditor';
+import { MacroEditor, ScriptArea, ScriptInput } from '../../pageobjects/CodeEditor';
 import { Section } from '../../pageobjects/Section';
 import { ResponsibleSelect } from '../../pageobjects/ResponsibleSelect';
 import { Select } from '../../pageobjects/Select';
@@ -50,23 +50,23 @@ export class TasksTester implements PartTest {
 }
 
 class Task extends PartObject {
-  name: CodeEditor;
-  description: CodeEditor;
-  category: CodeEditor;
+  name: MacroEditor;
+  description: MacroEditor;
+  category: MacroEditor;
   responsible: ResponsibleSelect;
   priority: Select;
   optionsSection: Section;
   skipTasklist: Checkbox;
-  delay: CodeEditor;
+  delay: ScriptInput;
   expirySection: Section;
-  timeout: CodeEditor;
+  timeout: ScriptInput;
   error: Select;
   expiryResponsbile: ResponsibleSelect;
   expiryPriority: Select;
   customFieldsSection: Section;
   customFields: Table;
   codeSection: Section;
-  code: CodeEditor;
+  code: ScriptArea;
 
   constructor(part: Part, private readonly nameValue: string, private readonly errorValue: RegExp) {
     super(part);

--- a/integrations/standalone/tests/mock/code-editor-input.spec.ts
+++ b/integrations/standalone/tests/mock/code-editor-input.spec.ts
@@ -1,6 +1,6 @@
 import { Page, test } from '@playwright/test';
 import { InscriptionView } from '../pageobjects/InscriptionView';
-import { CodeEditor } from '../pageobjects/CodeEditor';
+import { MacroEditor, ScriptInput } from '../pageobjects/CodeEditor';
 
 test.describe('Code Editor Input', () => {
   test('MacroInput - no new line', async ({ page }) => {
@@ -37,7 +37,7 @@ test.describe('Code Editor Input', () => {
     await assertAcceptScriptCellValue(page);
   });
 
-  async function assertNoNewLine(page: Page, name: CodeEditor) {
+  async function assertNoNewLine(page: Page, name: ScriptInput | MacroEditor) {
     await name.fill('test \nnewline');
     await page.keyboard.press('Tab');
     await name.expectValue('test newline');

--- a/integrations/standalone/tests/pageobjects/Composite.ts
+++ b/integrations/standalone/tests/pageobjects/Composite.ts
@@ -1,5 +1,5 @@
 import { Locator, Page } from '@playwright/test';
-import { CodeEditor } from './CodeEditor';
+import { MacroEditor, ScriptArea, ScriptInput } from './CodeEditor';
 import { ResponsibleSelect } from './ResponsibleSelect';
 import { Select } from './Select';
 import { ColumnType, Table } from './Table';
@@ -33,19 +33,19 @@ export abstract class Composite {
   }
 
   macroInput(label: string) {
-    return new CodeEditor(this.page, this.locator, true, label);
+    return new MacroEditor(this.page, this.locator, label);
   }
 
   macroArea(label: string) {
-    return new CodeEditor(this.page, this.locator, true, label);
+    return new MacroEditor(this.page, this.locator, label);
   }
 
   scriptInput(label: string) {
-    return new CodeEditor(this.page, this.locator, true, label);
+    return new ScriptInput(this.page, this.locator, label);
   }
 
   scriptArea() {
-    return new CodeEditor(this.page, this.locator, false);
+    return new ScriptArea(this.page, this.locator);
   }
 
   table(columns: ColumnType[]) {

--- a/integrations/standalone/tests/pageobjects/ResponsibleSelect.ts
+++ b/integrations/standalone/tests/pageobjects/ResponsibleSelect.ts
@@ -1,17 +1,17 @@
 import { Locator, Page, expect } from '@playwright/test';
 import { RESPONSIBLE_TYPE, ValuesAsUnion } from '@axonivy/inscription-protocol';
-import { CodeEditor } from './CodeEditor';
+import { ScriptInput } from './CodeEditor';
 
 export class ResponsibleSelect {
   private readonly locator: Locator;
   private readonly type: Locator;
-  private readonly script: CodeEditor;
+  private readonly script: ScriptInput;
   private readonly combo: Locator;
 
   constructor(page: Page, parentLocator: Locator, label: string) {
     this.locator = parentLocator.locator('.responsible-select', { has: page.getByLabel(label) }).first();
     this.type = parentLocator.getByLabel(label).first();
-    this.script = new CodeEditor(page, this.locator, true);
+    this.script = new ScriptInput(page, this.locator);
     this.combo = this.locator.getByRole('combobox').nth(1);
   }
 

--- a/packages/editor/src/App.css
+++ b/packages/editor/src/App.css
@@ -20,6 +20,7 @@
   --table-bg: #fcfcfc;
   --table-header-bg: #ffffff;
   --row-border: 1px solid var(--editor-bg);
+  --card-shadow: 0 1px 1px rgba(9, 30, 66, 0.25), 0 0 1px 1px rgba(9, 30, 66, 0.13);
 
   --error-color: #ff4a3d;
   --warning-color: #ff8614;
@@ -61,6 +62,7 @@
   --table-bg: #202020;
   --table-header-bg: #1b1b1b;
   --row-border: 1px solid var(--editor-bg);
+  --card-shadow: 0 1px 1px rgba(9, 30, 66, 0.25), 0 0 1px 1px rgba(9, 30, 66, 0.13);
 
   --error-color: #ff796f;
   --warning-color: #ff9f46;

--- a/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
@@ -1,26 +1,34 @@
 import './ScriptArea.css';
 import { Browser, useBrowser } from '../../../components/browser';
-import { Textarea } from '../input';
 import ResizableCodeEditor, { CodeEditorAreaProps } from './ResizableCodeEditor';
 import { monacoAutoFocus, useCodeEditorOnFocus, useModifyEditor } from './useCodeEditor';
 import { usePath } from '../../../context';
+import { CardArea } from '../output/CardText';
+import { ElementRef, useRef } from 'react';
 
 const MacroArea = (props: CodeEditorAreaProps) => {
   const { isFocusWithin, focusWithinProps } = useCodeEditorOnFocus();
   const browser = useBrowser();
   const { setEditor, modifyEditor } = useModifyEditor();
   const path = usePath();
+  const areaRef = useRef<ElementRef<'output'>>(null);
 
   return (
     // tabIndex is needed for safari to catch the focus when click on browser button
     <div className='script-area' {...focusWithinProps} tabIndex={1}>
       {isFocusWithin || browser.open ? (
         <>
-          <ResizableCodeEditor {...props} location={path} onMountFuncs={[setEditor, monacoAutoFocus]} macro={true} />
+          <ResizableCodeEditor
+            {...props}
+            location={path}
+            onMountFuncs={[setEditor, monacoAutoFocus]}
+            macro={true}
+            initHeight={areaRef.current?.offsetHeight}
+          />
           <Browser {...browser} types={['attr', 'cms']} accept={value => modifyEditor(`<%=${value}%>`)} location={path} />
         </>
       ) : (
-        <Textarea {...props} />
+        <CardArea {...props} ref={areaRef} />
       )}
     </div>
   );

--- a/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
@@ -1,9 +1,9 @@
 import './ScriptInput.css';
 import SingleLineCodeEditor, { CodeEditorInputProps } from './SingleLineCodeEditor';
 import { useCodeEditorOnFocus, useModifyEditor } from './useCodeEditor';
-import { Input } from '../input';
 import { Browser, useBrowser } from '../../../components/browser';
 import { usePath } from '../../../context';
+import { CardText } from '../output/CardText';
 
 type MacroInputProps = Omit<CodeEditorInputProps, 'context'>;
 
@@ -22,7 +22,7 @@ const MacroInput = (props: MacroInputProps) => {
           <Browser {...browser} types={['attr']} accept={value => modifyEditor(`<%=${value}%>`)} location={path} />
         </>
       ) : (
-        <Input {...props} />
+        <CardText {...props} />
       )}
     </div>
   );

--- a/packages/editor/src/components/widgets/output/CardText.css
+++ b/packages/editor/src/components/widgets/output/CardText.css
@@ -1,0 +1,34 @@
+.card-text {
+  border-radius: var(--border-radius);
+  border: var(--input-border);
+  background: var(--input-bg);
+  font-size: 12px;
+  line-height: 12px;
+  color: var(--input-color);
+  text-align: start;
+  padding: var(--input-padding);
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  min-height: 14px;
+}
+.card-text .card-text-line {
+  height: 20px;
+  white-space: pre-wrap;
+}
+
+.card-text .card {
+  color: var(--text-color);
+  padding: 2px 0.24em;
+  background-color: var(--editor-bg);
+  border-radius: var(--border-radius);
+  box-shadow: var(--card-shadow);
+  user-select: none;
+}
+.card-text .card .card-icon {
+  margin-right: var(--size-1);
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: bottom;
+}

--- a/packages/editor/src/components/widgets/output/CardText.test.tsx
+++ b/packages/editor/src/components/widgets/output/CardText.test.tsx
@@ -1,0 +1,56 @@
+import { CardArea, CardText } from './CardText';
+import { render, screen } from 'test-utils';
+
+describe('CardText', () => {
+  function renderText(text: string) {
+    render(
+      <>
+        <label id='label' htmlFor='text'>
+          Label
+        </label>
+        <CardText id='text' aria-labelledby='label' value={text} />
+      </>
+    );
+  }
+
+  test('text', async () => {
+    renderText('Hello World');
+    expect(screen.getByLabelText('Label')).toHaveTextContent('Hello World');
+  });
+
+  test('text with makros', async () => {
+    renderText('Hello <%= in.accept %> World <%=ivy.cms.co("/bla")%>');
+    expect(screen.getByLabelText('Label')).toHaveTextContent('Hello in.accept World ivy.cms.co("/bla")');
+  });
+});
+
+describe('CardArea', () => {
+  function renderArea(text: string) {
+    render(
+      <>
+        <label id='label' htmlFor='text'>
+          Label
+        </label>
+        <CardArea id='text' aria-labelledby='label' value={text} />
+      </>
+    );
+  }
+
+  test('area', async () => {
+    renderArea('Hello \nWorld');
+    expect(screen.getByLabelText('Label')).toHaveTextContent('Hello World');
+    const lines = screen.getAllByRole('row');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toHaveTextContent('Hello');
+    expect(lines[1]).toHaveTextContent('World');
+  });
+
+  test('area with makros', async () => {
+    renderArea('Hello <%= in.accept %> World \n<%=ivy.cms.co("/bla")%>');
+    expect(screen.getByLabelText('Label')).toHaveTextContent('Hello in.accept World ivy.cms.co("/bla")');
+    const lines = screen.getAllByRole('row');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toHaveTextContent('Hello in.accept World');
+    expect(lines[1]).toHaveTextContent('ivy.cms.co("/bla")');
+  });
+});

--- a/packages/editor/src/components/widgets/output/CardText.tsx
+++ b/packages/editor/src/components/widgets/output/CardText.tsx
@@ -1,0 +1,59 @@
+import './CardText.css';
+import { IvyIcons } from '@axonivy/editor-icons';
+import IvyIcon from '../IvyIcon';
+import { splitMacroExpressions, splitNewLine } from '../../../utils/utils';
+import { FieldsetInputProps } from '../fieldset';
+import { ElementRef, forwardRef } from 'react';
+
+export type CardTextProps = Partial<FieldsetInputProps> & {
+  value?: string;
+};
+
+const Card = ({ part }: { part: string }) => {
+  const text = part.substring(3, part.length - 2).trim();
+  return (
+    <span className='card'>
+      <span className='card-icon'>
+        <IvyIcon icon={IvyIcons.Program} />
+      </span>
+      {text}
+    </span>
+  );
+};
+
+const CardOrText = ({ part }: { part: string }) => {
+  if (part.startsWith('<%=')) {
+    return <Card part={part} />;
+  }
+  return <span className='text'>{part}</span>;
+};
+
+const CardLine = ({ parts }: { parts: string[] }) => (
+  <>
+    {parts.map((part, index) => (
+      <CardOrText key={index} part={part} />
+    ))}
+  </>
+);
+
+export const CardText = ({ value, ...props }: CardTextProps) => {
+  const parts = splitMacroExpressions(value ?? '');
+  return (
+    <output className='card-text' {...props}>
+      <CardLine parts={parts} />
+    </output>
+  );
+};
+
+export const CardArea = forwardRef<ElementRef<'output'>, CardTextProps>(({ value, ...props }, forwardRef) => {
+  const lines = splitNewLine(value ?? '').map(line => splitMacroExpressions(line));
+  return (
+    <output className='card-text' {...props} ref={forwardRef}>
+      {lines.map((line, index) => (
+        <div key={index} className='card-text-line' role='row'>
+          <CardLine parts={line} />
+        </div>
+      ))}
+    </output>
+  );
+});

--- a/packages/editor/src/utils/utils.test.ts
+++ b/packages/editor/src/utils/utils.test.ts
@@ -1,0 +1,34 @@
+import { generateId, splitMacroExpressions, splitNewLine } from './utils';
+
+test('generateId', () => {
+  expect(generateId()).toEqual('0');
+  expect(generateId()).toEqual('1');
+  expect(generateId()).toEqual('2');
+});
+
+test('splitNewLine', () => {
+  expect(splitNewLine('')).toEqual(['']);
+  expect(splitNewLine('abc')).toEqual(['abc']);
+  expect(splitNewLine('abc\ndef')).toEqual(['abc', 'def']);
+  expect(splitNewLine('abc\rdef')).toEqual(['abc', 'def']);
+  expect(splitNewLine('abc\r\ndef')).toEqual(['abc', 'def']);
+});
+
+test('splitMacroExpressions', () => {
+  expect(splitMacroExpressions('')).toEqual([]);
+  expect(splitMacroExpressions('abc')).toEqual(['abc']);
+  expect(splitMacroExpressions('abc <%= ivy.cms.co("hi") %>')).toEqual(['abc ', '<%= ivy.cms.co("hi") %>']);
+  expect(splitMacroExpressions('abc <%= ivy.cms.co("hi") %>, hi')).toEqual(['abc ', '<%= ivy.cms.co("hi") %>', ', hi']);
+  expect(splitMacroExpressions('abc <%= ivy.cms.co("hi") %>, hi <%=in.accept%>')).toEqual([
+    'abc ',
+    '<%= ivy.cms.co("hi") %>',
+    ', hi ',
+    '<%=in.accept%>'
+  ]);
+  expect(splitMacroExpressions('<%= ivy.cms.co("hi") %><%=in.accept%>')).toEqual(['<%= ivy.cms.co("hi") %>', '<%=in.accept%>']);
+});
+
+test('splitMacroExpressions not supported', () => {
+  //The following test should result in ['abc ', '<%= ivy.cms.co("hi %>") %>']
+  expect(splitMacroExpressions('abc <%= ivy.cms.co("hi %>") %>')).toEqual(['abc ', '<%= ivy.cms.co("hi %>', '") %>']);
+});

--- a/packages/editor/src/utils/utils.ts
+++ b/packages/editor/src/utils/utils.ts
@@ -3,3 +3,11 @@ let idCounter = 0;
 export function generateId() {
   return String(idCounter++);
 }
+
+export function splitNewLine(text: string) {
+  return text.split(/\r\n|\r|\n/);
+}
+
+export function splitMacroExpressions(text: string) {
+  return text.split(/(<%=\s*[\s\S]*?\s*%>)/gm).filter(subtext => subtext.length > 0);
+}


### PR DESCRIPTION
- Show output with card badges for macro expressions if macro editors are in read mode
- Init MacroArea monaco editor with the same height as the read mode was
- Specific CodeEditor page objects

![image](https://github.com/axonivy/inscription-client/assets/42733123/b42dcffb-fcc4-42ad-bd16-9a68a873847c)
