### PR TITLE
Fix reset functionality

### DIFF
--- a/integrations/standalone/tests/integration/parts/call.ts
+++ b/integrations/standalone/tests/integration/parts/call.ts
@@ -19,13 +19,13 @@ class Call extends PartObject {
   async fill() {
     await this.call.choose(this.selectValue);
     await this.mapping.row(2).column(2).fill('"test"');
-    await this.code.fill('ivy.log.info("hi");');
+    await this.code.fill('code');
   }
 
   async assertFill() {
     await this.call.expectValue(this.assertSelectValue);
     await this.mapping.row(2).column(2).expectValue('"test"');
-    await this.code.expectValue('ivy.log.info("hi");');
+    await this.code.expectValue('code');
   }
 
   async clear() {

--- a/integrations/standalone/tests/integration/parts/code.ts
+++ b/integrations/standalone/tests/integration/parts/code.ts
@@ -14,12 +14,12 @@ class Code extends PartObject {
   }
 
   async fill() {
-    await this.code.fill('ivy.log.info("hi");');
+    await this.code.fill('code');
     await this.sudo.check();
   }
 
   async assertFill() {
-    await this.code.expectValue('ivy.log.info("hi");');
+    await this.code.expectValue('code');
     await this.sudo.expectChecked();
   }
 

--- a/integrations/standalone/tests/integration/parts/output.ts
+++ b/integrations/standalone/tests/integration/parts/output.ts
@@ -12,13 +12,13 @@ export class OutputTester implements PartTest {
   async fill({ page }: Part) {
     await TableUtil.fillExpression(page, 1, '"bla"');
     if (this.hasCode) {
-      await CodeEditorUtil.fill(page, 'ivy.log.info("hi");');
+      await CodeEditorUtil.fill(page, 'code');
     }
   }
   async assertFill({ page }: Part) {
     await TableUtil.assertRow(page, 1, ['"bla"']);
     if (this.hasCode) {
-      await CodeEditorUtil.assertValue(page, 'ivy.log.info("hi");');
+      await CodeEditorUtil.assertValue(page, 'code');
     }
   }
   async clear({ page }: Part) {

--- a/integrations/standalone/tests/integration/parts/result.ts
+++ b/integrations/standalone/tests/integration/parts/result.ts
@@ -19,7 +19,7 @@ export class ResultTester implements PartTest {
       await TableUtil.fillRow(page, 0, ['param', 'String', 'desc']);
     }
     await TableUtil.fillExpression(page, 2, '"bla"');
-    await CodeEditorUtil.fill(page, 'ivy.log.info("hi");');
+    await CodeEditorUtil.fill(page, 'code');
   }
   async assertFill({ page }: Part) {
     await CollapseUtil.open(page, 'Result parameters');
@@ -29,7 +29,7 @@ export class ResultTester implements PartTest {
       await TableUtil.assertRow(page, 0, ['param', 'String', 'desc']);
     }
     await TableUtil.assertRow(page, 2, ['"bla"']);
-    await CodeEditorUtil.assertValue(page, 'ivy.log.info("hi");');
+    await CodeEditorUtil.assertValue(page, 'code');
   }
   async clear({ page }: Part) {
     await CollapseUtil.open(page, 'Result parameters');

--- a/integrations/standalone/tests/integration/parts/start.ts
+++ b/integrations/standalone/tests/integration/parts/start.ts
@@ -21,7 +21,7 @@ export class StartTester implements PartTest {
       await TableUtil.fillRow(page, 0, ['param', 'String', 'desc']);
     }
     await TableUtil.fillExpression(page, 1, '"bla"');
-    await CodeEditorUtil.fill(page, 'ivy.log.info("hi");');
+    await CodeEditorUtil.fill(page, 'code');
   }
   async assertFill({ page }: Part) {
     await expect(page.getByLabel('Signature')).toHaveValue('myStart');
@@ -32,7 +32,7 @@ export class StartTester implements PartTest {
       await TableUtil.assertRow(page, 0, ['param', 'String', 'desc']);
     }
     await TableUtil.assertRow(page, 1, ['"bla"']);
-    await CodeEditorUtil.assertValue(page, 'ivy.log.info("hi");');
+    await CodeEditorUtil.assertValue(page, 'code');
   }
   async clear({ page }: Part) {
     await page.getByLabel('Signature').clear();

--- a/integrations/standalone/tests/mock/code-editor-input.spec.ts
+++ b/integrations/standalone/tests/mock/code-editor-input.spec.ts
@@ -39,7 +39,6 @@ test.describe('Code Editor Input', () => {
 
   async function assertNoNewLine(page: Page, name: ScriptInput | MacroEditor) {
     await name.fill('test \nnewline');
-    await page.keyboard.press('Tab');
     await name.expectValue('test newline');
   }
 

--- a/integrations/standalone/tests/mock/reset.spec.ts
+++ b/integrations/standalone/tests/mock/reset.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+import { InscriptionView } from '../pageobjects/InscriptionView';
+
+test.describe('Reset part', () => {
+  test('reset button', async ({ page }) => {
+    const inscriptionView = new InscriptionView(page);
+    await inscriptionView.mock();
+    const part = inscriptionView.accordion('Name');
+    await part.toggle();
+
+    const resetBtn = part.resetButton();
+    await expect(resetBtn).not.toBeVisible();
+    const name = part.textArea('Display name');
+    await name.fill('bla');
+    await expect(resetBtn).toBeVisible();
+
+    await resetBtn.click();
+    await name.expectValue('test name');
+  });
+});

--- a/integrations/standalone/tests/pageobjects/Accordion.ts
+++ b/integrations/standalone/tests/pageobjects/Accordion.ts
@@ -27,6 +27,10 @@ export class Accordion extends Part {
     return new Tab(this.page, this.locator, label);
   }
 
+  resetButton() {
+    return this.page.locator('.accordion-header-group button');
+  }
+
   async expectState(state: PartStateFlag) {
     const stateLocator = this.locator.locator('.accordion-state');
     await expect(stateLocator).toHaveAttribute('data-state', state);

--- a/integrations/standalone/tests/pageobjects/CodeEditor.ts
+++ b/integrations/standalone/tests/pageobjects/CodeEditor.ts
@@ -1,23 +1,27 @@
 import { Locator, Page, expect } from '@playwright/test';
-import { FocusCodeEditorUtil } from '../utils/code-editor-util';
+import { CodeEditorUtil } from '../utils/code-editor-util';
 
 class CodeEditor {
   protected contentAssist: Locator;
 
-  constructor(readonly page: Page, readonly locator: Locator, readonly value: Locator, parentLocator: Locator) {
+  constructor(readonly page: Page, readonly locator: Locator, readonly value: Locator, readonly parentLocator: Locator) {
     this.contentAssist = parentLocator.locator('div.suggest-widget');
   }
 
   async triggerContentAssist() {
-    await FocusCodeEditorUtil.triggerContentAssist(this.page, this.locator);
+    await CodeEditorUtil.triggerContentAssistWithLocator(this.page, this.locator);
   }
 
   async fill(value: string) {
-    await FocusCodeEditorUtil.fill(this.page, this.locator, value);
+    await this.locator.click();
+    await CodeEditorUtil.type(this.page, value);
+    await this.page.locator('*:focus').blur();
   }
 
   async clear() {
-    await FocusCodeEditorUtil.clear(this.page, this.locator);
+    await this.locator.click();
+    await CodeEditorUtil.clear(this.page);
+    await this.page.locator('*:focus').blur();
   }
 
   async expectValue(value: string) {

--- a/integrations/standalone/tests/utils/code-editor-util.ts
+++ b/integrations/standalone/tests/utils/code-editor-util.ts
@@ -47,23 +47,3 @@ export namespace CodeEditorUtil {
     await expect(content).toContainText(expectedContentAssist);
   }
 }
-
-export namespace FocusCodeEditorUtil {
-  export async function fill(page: Page, locator: Locator, value: string) {
-    await locator.click();
-    await CodeEditorUtil.type(page, value);
-  }
-
-  export async function clear(page: Page, locator: Locator) {
-    await locator.click();
-    await CodeEditorUtil.clear(page);
-  }
-
-  export async function triggerContentAssist(page: Page, locator: Locator) {
-    await CodeEditorUtil.triggerContentAssistWithLocator(page, locator);
-  }
-
-  export async function assertContentAssist(page: Page, expectedContentAssist: string) {
-    await CodeEditorUtil.assertContentAssist(page, expectedContentAssist);
-  }
-}

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -10,8 +10,10 @@ import { Unary } from './types/lambda';
 
 function App(props: InscriptionContext) {
   const [context, setContext] = useState(props);
+  const [initData, setInitData] = useState<ElementData>();
   useEffect(() => {
     setContext(props);
+    setInitData(undefined);
   }, [props]);
 
   const client = useClient();
@@ -45,8 +47,9 @@ function App(props: InscriptionContext) {
   useEffect(() => {
     if (isSuccess) {
       setContext(data.context);
+      setInitData(initData => (initData ? initData : data.data));
     }
-  }, [data?.context, isSuccess]);
+  }, [data, isSuccess]);
 
   const { data: validations } = useQuery({
     queryKey: queryKeys.validation(),
@@ -95,7 +98,7 @@ function App(props: InscriptionContext) {
             data: data.data,
             setData: mutation.mutate,
             defaultData: data.defaults,
-            initData: data.data,
+            initData: initData ? initData : data.data,
             validations
           }}
         >

--- a/packages/editor/src/components/widgets/accordion/Accordion.tsx
+++ b/packages/editor/src/components/widgets/accordion/Accordion.tsx
@@ -11,26 +11,22 @@ type AccordionRootProps = {
   children: ReactNode;
 };
 
-export const AccordionRoot = ({ value, onChange, children }: AccordionRootProps) => {
-  return (
-    <Root type='single' className='accordion-root' collapsible={true} value={value} onValueChange={onChange}>
-      {children}
-    </Root>
-  );
-};
+export const AccordionRoot = ({ value, onChange, children }: AccordionRootProps) => (
+  <Root type='single' className='accordion-root' collapsible={true} value={value} onValueChange={onChange}>
+    {children}
+  </Root>
+);
 
 type AccordionItemProps = {
   value: string;
   children: ReactNode;
 };
 
-export const AccordionItem = ({ value, children }: AccordionItemProps) => {
-  return (
-    <Item value={value} className='accordion-item'>
-      {children}
-    </Item>
-  );
-};
+export const AccordionItem = ({ value, children }: AccordionItemProps) => (
+  <Item value={value} className='accordion-item'>
+    {children}
+  </Item>
+);
 
 type AccordionHeaderProps = {
   title?: string;
@@ -38,24 +34,20 @@ type AccordionHeaderProps = {
   children: ReactNode;
 };
 
-export const AccordionHeader = ({ title, control, children, ...props }: AccordionHeaderProps) => {
-  return (
-    <Header className='accordion-header' title={title}>
-      <Trigger className='accordion-trigger'>{children}</Trigger>
-      <div className='accordion-header-group'>
-        {control && <Button icon={control.icon} onClick={control.action} aria-label={control.label} />}
-        <IvyIcon icon={IvyIcons.AngleDown} />
-      </div>
-    </Header>
-  );
-};
+export const AccordionHeader = ({ title, control, children }: AccordionHeaderProps) => (
+  <Header className='accordion-header' title={title}>
+    <Trigger className='accordion-trigger'>{children}</Trigger>
+    <div className='accordion-header-group'>
+      {control && <Button icon={control.icon} onClick={control.action} aria-label={control.label} />}
+      <IvyIcon icon={IvyIcons.AngleDown} />
+    </div>
+  </Header>
+);
 
-export const AccordionContent = ({ children, className, ...props }: { children: ReactNode } & ComponentProps<'div'>) => {
-  return (
-    <Content className='accordion-content'>
-      <div {...props} className={`accordion-content-data ${className ?? ''}`}>
-        {children}
-      </div>
-    </Content>
-  );
-};
+export const AccordionContent = ({ children, className, ...props }: { children: ReactNode } & ComponentProps<'div'>) => (
+  <Content className='accordion-content'>
+    <div {...props} className={`accordion-content-data ${className ?? ''}`}>
+      {children}
+    </div>
+  </Content>
+);

--- a/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
@@ -6,8 +6,8 @@ import { usePath } from '../../../context';
 import { CardArea } from '../output/CardText';
 import { ElementRef, useRef } from 'react';
 
-const MacroArea = (props: CodeEditorAreaProps) => {
-  const { isFocusWithin, focusWithinProps } = useCodeEditorOnFocus();
+const MacroArea = ({ value, onChange, ...props }: CodeEditorAreaProps) => {
+  const { isFocusWithin, focusWithinProps, focusValue } = useCodeEditorOnFocus(value, onChange);
   const browser = useBrowser();
   const { setEditor, modifyEditor } = useModifyEditor();
   const path = usePath();
@@ -19,6 +19,7 @@ const MacroArea = (props: CodeEditorAreaProps) => {
       {isFocusWithin || browser.open ? (
         <>
           <ResizableCodeEditor
+            {...focusValue}
             {...props}
             location={path}
             onMountFuncs={[setEditor, monacoAutoFocus]}
@@ -28,7 +29,7 @@ const MacroArea = (props: CodeEditorAreaProps) => {
           <Browser {...browser} types={['attr', 'cms']} accept={value => modifyEditor(`<%=${value}%>`)} location={path} />
         </>
       ) : (
-        <CardArea {...props} ref={areaRef} />
+        <CardArea value={value} {...props} ref={areaRef} />
       )}
     </div>
   );

--- a/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
@@ -7,8 +7,8 @@ import { CardText } from '../output/CardText';
 
 type MacroInputProps = Omit<CodeEditorInputProps, 'context'>;
 
-const MacroInput = (props: MacroInputProps) => {
-  const { isFocusWithin, focusWithinProps } = useCodeEditorOnFocus();
+const MacroInput = ({ value, onChange, ...props }: MacroInputProps) => {
+  const { isFocusWithin, focusWithinProps, focusValue } = useCodeEditorOnFocus(value, onChange);
   const browser = useBrowser();
   const { setEditor, modifyEditor } = useModifyEditor();
   const path = usePath();
@@ -18,11 +18,11 @@ const MacroInput = (props: MacroInputProps) => {
     <div className='script-input' {...focusWithinProps} tabIndex={1}>
       {isFocusWithin || browser.open ? (
         <>
-          <SingleLineCodeEditor {...props} context={{ location: path }} macro={true} onMountFuncs={[setEditor]} />
+          <SingleLineCodeEditor {...focusValue} {...props} context={{ location: path }} macro={true} onMountFuncs={[setEditor]} />
           <Browser {...browser} types={['attr']} accept={value => modifyEditor(`<%=${value}%>`)} location={path} />
         </>
       ) : (
-        <CardText {...props} />
+        <CardText value={value} {...props} />
       )}
     </div>
   );

--- a/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
@@ -5,8 +5,8 @@ import { useCodeEditorOnFocus, useModifyEditor } from './useCodeEditor';
 import { Browser, useBrowser } from '../../../components/browser';
 import { usePath } from '../../../context';
 
-const ScriptInput = ({ type, editorOptions, keyActions, ...props }: CodeEditorInputProps & { type: string }) => {
-  const { isFocusWithin, focusWithinProps } = useCodeEditorOnFocus();
+const ScriptInput = ({ value, onChange, type, editorOptions, keyActions, ...props }: CodeEditorInputProps & { type: string }) => {
+  const { isFocusWithin, focusWithinProps, focusValue } = useCodeEditorOnFocus(value, onChange);
   const browser = useBrowser();
   const { setEditor, modifyEditor } = useModifyEditor();
   const path = usePath();
@@ -17,6 +17,7 @@ const ScriptInput = ({ type, editorOptions, keyActions, ...props }: CodeEditorIn
       {isFocusWithin || browser.open ? (
         <>
           <SingleLineCodeEditor
+            {...focusValue}
             {...props}
             context={{ type, location: path }}
             onMountFuncs={[setEditor]}
@@ -26,7 +27,7 @@ const ScriptInput = ({ type, editorOptions, keyActions, ...props }: CodeEditorIn
           <Browser {...browser} types={['attr', 'cms']} accept={modifyEditor} location={path} />
         </>
       ) : (
-        <Input {...props} />
+        <Input value={value} onChange={onChange} {...props} />
       )}
     </div>
   );

--- a/packages/editor/src/components/widgets/code-editor/index.ts
+++ b/packages/editor/src/components/widgets/code-editor/index.ts
@@ -2,3 +2,4 @@ export { default as ScriptArea } from './ScriptArea';
 export { default as ScriptInput } from './ScriptInput';
 export { default as MacroArea } from './MacroArea';
 export { default as MacroInput } from './MacroInput';
+export { default as SingleLineCodeEditor } from './SingleLineCodeEditor';

--- a/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
+++ b/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
@@ -1,11 +1,15 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { useFocusWithin } from 'react-aria';
 
-export const useCodeEditorOnFocus = () => {
+export const useCodeEditorOnFocus = (initialValue: string, onChange: (change: string) => void) => {
   const [isFocusWithin, setFocusWithin] = useState(false);
-  let { focusWithinProps } = useFocusWithin({ onFocusWithinChange: setFocusWithin });
-  return { isFocusWithin, focusWithinProps };
+  const [focusValue, setFocusValue] = useState(initialValue);
+  useEffect(() => {
+    setFocusValue(initialValue);
+  }, [initialValue]);
+  const { focusWithinProps } = useFocusWithin({ onFocusWithinChange: setFocusWithin, onBlurWithin: () => onChange(focusValue) });
+  return { isFocusWithin, focusWithinProps, focusValue: { value: focusValue, onChange: setFocusValue } };
 };
 
 export const monacoAutoFocus = (editor: monaco.editor.IStandaloneCodeEditor) => {

--- a/packages/editor/src/components/widgets/table/cell/ScriptCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/ScriptCell.tsx
@@ -5,10 +5,12 @@ import { useEffect, useRef, useState } from 'react';
 import { Popover, PopoverArrow, PopoverClose, PopoverContent, PopoverPortal, PopoverTrigger } from '@radix-ui/react-popover';
 import { Fieldset, useFieldset } from '../../fieldset';
 import IvyIcon from '../../IvyIcon';
-import { useEditorContext } from '../../../../context';
+import { useEditorContext, usePath } from '../../../../context';
 import { IvyIcons } from '@axonivy/editor-icons';
 import { Input } from '../../input';
-import { ScriptInput } from '../../code-editor';
+import { SingleLineCodeEditor } from '../../code-editor';
+import { Browser, useBrowser } from '../../../../components/browser';
+import { useModifyEditor } from '../../code-editor/useCodeEditor';
 
 declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -43,6 +45,9 @@ export function ScriptCell<TData>({ cell, type }: ScriptCellProps<TData>) {
   const editorContext = useEditorContext();
   const codeFieldset = useFieldset();
   const closeRef = useRef<HTMLButtonElement>(null);
+  const path = usePath();
+  const browser = useBrowser();
+  const { setEditor, modifyEditor } = useModifyEditor();
 
   return (
     <>
@@ -63,18 +68,22 @@ export function ScriptCell<TData>({ cell, type }: ScriptCellProps<TData>) {
           <PopoverPortal container={editorContext.editorRef.current}>
             <PopoverContent className='popover-content' sideOffset={5} align={'end'}>
               <Fieldset label='Code' {...codeFieldset.labelProps}>
-                <ScriptInput
-                  value={value}
-                  onChange={setValue}
-                  type={type}
-                  editorOptions={{ fixedOverflowWidgets: false }}
-                  keyActions={{
-                    enter: () => closeRef.current?.click(),
-                    escape: () => closeRef.current?.click(),
-                    tab: () => closeRef.current?.click()
-                  }}
-                  {...codeFieldset.inputProps}
-                />
+                <div className='script-input'>
+                  <SingleLineCodeEditor
+                    value={value}
+                    onChange={setValue}
+                    context={{ type, location: path }}
+                    onMountFuncs={[setEditor]}
+                    editorOptions={{ fixedOverflowWidgets: false }}
+                    keyActions={{
+                      enter: () => closeRef.current?.click(),
+                      escape: () => closeRef.current?.click(),
+                      tab: () => closeRef.current?.click()
+                    }}
+                    {...codeFieldset.inputProps}
+                  />
+                  <Browser {...browser} types={['attr', 'cms']} accept={modifyEditor} location={path} />
+                </div>
               </Fieldset>
               <PopoverClose className='popover-close' aria-label='Close' ref={closeRef}>
                 <IvyIcon icon={IvyIcons.Add} rotate={45} />

--- a/packages/editor/src/test-utils/setupTests.tsx
+++ b/packages/editor/src/test-utils/setupTests.tsx
@@ -16,8 +16,8 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
-const CodeEditorMock = (props: { id: string; value: string; onChange: (value: string) => void }) => {
-  return <input data-testid='code-editor' id={props.id} value={props.value} onChange={e => props.onChange(e.target.value)} />;
+const CodeEditorMock = ({ onChange, ...props }: { id: string; value: string; onChange: (value: string) => void }) => {
+  return <input data-testid='code-editor' {...props} onChange={e => onChange(e.target.value)} />;
 };
 
 jest.mock('../components/widgets/code-editor', () => ({
@@ -25,5 +25,6 @@ jest.mock('../components/widgets/code-editor', () => ({
   ScriptArea: CodeEditorMock,
   ScriptInput: CodeEditorMock,
   MacroArea: CodeEditorMock,
-  MacroInput: CodeEditorMock
+  MacroInput: CodeEditorMock,
+  SingleLineCodeEditor: CodeEditorMock
 }));


### PR DESCRIPTION
- Fix broken reset functionality and add test for it
- Change MacroArea, MacroInput and ScriptInput fields -> save data not after every change only after focus loose
  - Reduce pressure on server (especially in the test case)
  - No nervous validation messages while write something (the validations are shown anyways in the monaco editor) 