### PR TITLE
XIVY-11705 Add EditorPart

### DIFF
--- a/packages/editor/src/components/editors/activity/interface.tsx
+++ b/packages/editor/src/components/editors/activity/interface.tsx
@@ -15,7 +15,8 @@ import {
   useWsResponsePart,
   useRestResponsePart,
   useRestRequestPart,
-  useProgramInterfaceStartPart
+  useProgramInterfaceStartPart,
+  useEditorPart
 } from '../../../components/parts';
 
 const DatabaseEditor = memo(() => {
@@ -52,7 +53,8 @@ const EMailEditor = memo(() => {
 const ProgramInterfaceEditor = memo(() => {
   const name = useNamePart();
   const start = useProgramInterfaceStartPart();
-  return <InscriptionEditor icon={IvyIcons.Program} parts={[name, start]} />;
+  const editor = useEditorPart();
+  return <InscriptionEditor icon={IvyIcons.Program} parts={[name, start, editor]} />;
 });
 
 export const interfaceActivityEditors = new Map<ElementType, ReactNode>([

--- a/packages/editor/src/components/editors/event/intermediate.tsx
+++ b/packages/editor/src/components/editors/event/intermediate.tsx
@@ -3,7 +3,15 @@ import { IvyIcons } from '@axonivy/editor-icons';
 import { ElementType } from '@axonivy/inscription-protocol';
 import { memo, ReactNode } from 'react';
 import InscriptionEditor from '../InscriptionEditor';
-import { useCasePart, useEndPagePart, useEventPart, useNamePart, useOutputPart, useTaskPart } from '../../../components/parts';
+import {
+  useCasePart,
+  useEditorPart,
+  useEndPagePart,
+  useEventPart,
+  useNamePart,
+  useOutputPart,
+  useTaskPart
+} from '../../../components/parts';
 
 const TaskSwitchEventEditor = memo(() => {
   const name = useNamePart();
@@ -17,9 +25,10 @@ const TaskSwitchEventEditor = memo(() => {
 const WaitEventEditor = memo(() => {
   const name = useNamePart();
   const event = useEventPart();
+  const editor = useEditorPart();
   const task = useTaskPart({ type: 'wait' });
   const output = useOutputPart();
-  return <InscriptionEditor icon={IvyIcons.Wait} parts={[name, event, task, output]} />;
+  return <InscriptionEditor icon={IvyIcons.Wait} parts={[name, event, editor, task, output]} />;
 });
 
 export const intermediateEventEditors = new Map<ElementType, ReactNode>([

--- a/packages/editor/src/components/editors/event/start.tsx
+++ b/packages/editor/src/components/editors/event/start.tsx
@@ -14,7 +14,8 @@ import {
   useErrorCatchPart,
   useTriggerPart,
   useRequestPart,
-  useProgramStartPart
+  useProgramStartPart,
+  useEditorPart
 } from '../../../components/parts';
 
 const RequestStartEditor = memo(() => {
@@ -44,7 +45,8 @@ const ErrorStartEventEditor = memo(() => {
 const ProgramStartEditor = memo(() => {
   const name = useNamePart();
   const start = useProgramStartPart();
-  return <InscriptionEditor icon={IvyIcons.StartProgram} parts={[name, start]} />;
+  const editor = useEditorPart();
+  return <InscriptionEditor icon={IvyIcons.StartProgram} parts={[name, start, editor]} />;
 });
 
 export const startEventEditors = new Map<ElementType, ReactNode>([

--- a/packages/editor/src/components/parts/index.ts
+++ b/packages/editor/src/components/parts/index.ts
@@ -30,3 +30,4 @@ export * from './rest-request/RestRequestPart';
 export * from './program/event/ProgramStartPart';
 export * from './program/activity/ProgramInterfaceStartPart';
 export * from './program/intermediate/EventPart';
+export * from './program/editor/EditorPart';

--- a/packages/editor/src/components/parts/program/JavaClassSelector.test.tsx
+++ b/packages/editor/src/components/parts/program/JavaClassSelector.test.tsx
@@ -1,0 +1,25 @@
+import { SelectUtil, render } from 'test-utils';
+import { ProgramStartData } from '@axonivy/inscription-protocol';
+import JavaClassSelector from './JavaClassSelector';
+
+describe('StartPart', () => {
+  function renderPart(data?: ProgramStartData) {
+    render(<JavaClassSelector javaClass='' onChange={() => {}} type='START' />, {
+      wrapperProps: {
+        data: data && { config: data },
+        meta: {
+          javaClasses: [
+            { fullQualifiedName: 'This is the full name', name: 'this is the name', packageName: 'coolpackage' },
+            { fullQualifiedName: 'Amazing Fullname', name: 'Name is okay', packageName: 'Packagename' }
+          ]
+        }
+      }
+    });
+  }
+
+  test('meta', async () => {
+    renderPart();
+    await SelectUtil.assertEmpty();
+    await SelectUtil.assertOptionsCount(2);
+  });
+});

--- a/packages/editor/src/components/parts/program/activity/ProgramInterfaceStartPart.test.tsx
+++ b/packages/editor/src/components/parts/program/activity/ProgramInterfaceStartPart.test.tsx
@@ -17,8 +17,6 @@ describe('ProgramInterfaceStartPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await SelectUtil.assertEmpty();
-    //await SelectUtil.assertOptionsCount(1);
     await CollapsableUtil.assertClosed('Program');
     await CollapsableUtil.assertClosed('Timeout');
   });

--- a/packages/editor/src/components/parts/program/editor/Editor.css
+++ b/packages/editor/src/components/parts/program/editor/Editor.css
@@ -1,0 +1,11 @@
+.info-text {
+  display: flex;
+  flex-direction: column;
+  padding-inline: var(--size-1);
+  gap: var(--size-1);
+  font-size: 12px;
+}
+
+.info-text p {
+  margin: 0;
+}

--- a/packages/editor/src/components/parts/program/editor/EditorPart.test.tsx
+++ b/packages/editor/src/components/parts/program/editor/EditorPart.test.tsx
@@ -1,0 +1,68 @@
+import { DeepPartial, render, renderHook, screen } from 'test-utils';
+import { EditorData, ElementData, InscriptionValidation } from '@axonivy/inscription-protocol';
+import { PartStateFlag } from '../../../editors';
+import { useEditorPart } from './EditorPart';
+
+const Part = () => {
+  const part = useEditorPart();
+  return <>{part.content}</>;
+};
+
+describe('EditorPart', () => {
+  function renderPart(data?: DeepPartial<EditorData>) {
+    render(<Part />, {
+      wrapperProps: {
+        data: data && { config: data },
+        meta: {
+          widgets: [
+            { text: 'Path of directory to scan', multiline: false },
+            { multiline: false },
+            { text: 'Multiline-Text', multiline: true }
+          ]
+        }
+      }
+    });
+  }
+
+  test('empty data', async () => {
+    render(<Part />);
+    expect(screen.getByTitle('There is no editor for this bean')).toBeInTheDocument();
+  });
+
+  test('full data', async () => {
+    renderPart({
+      userConfig: '123'
+    });
+    await screen.findByText('Path of directory to scan');
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+  });
+
+  function assertState(expectedState: PartStateFlag, data?: DeepPartial<EditorData>, validation?: InscriptionValidation) {
+    const { result } = renderHook(() => useEditorPart(), {
+      wrapperProps: { data: data && { config: data }, validations: validation && [validation] }
+    });
+    expect(result.current.state.state).toEqual(expectedState);
+  }
+
+  test('configured', async () => {
+    assertState('empty');
+    assertState('configured', {
+      userConfig: 'test123'
+    });
+  });
+
+  test('reset', () => {
+    let data: DeepPartial<ElementData> = {
+      config: {
+        userConfig: 'test'
+      }
+    };
+    const view = renderHook(() => useEditorPart(), {
+      wrapperProps: { data, setData: newData => (data = newData) }
+    });
+    expect(view.result.current.reset.dirty).toEqual(true);
+
+    view.result.current.reset.action();
+    expect(data.config?.userConfig).toEqual('');
+  });
+});

--- a/packages/editor/src/components/parts/program/editor/EditorPart.tsx
+++ b/packages/editor/src/components/parts/program/editor/EditorPart.tsx
@@ -1,0 +1,76 @@
+import { EditorData, Label, Script, Text, Widget } from '@axonivy/inscription-protocol';
+import { PartProps, usePartDirty, usePartState } from '../../../editors';
+import { useEditorContext, useMeta, useValidations } from '../../../../context';
+import { useEditorData } from './useEditorData';
+import { Input, MessageText, ScriptInput } from '../../../../components/widgets';
+import './Editor.css';
+
+export function useEditorPart(): PartProps {
+  const { config, defaultConfig, initConfig, reset } = useEditorData();
+  const compareData = (data: EditorData) => [data.userConfig];
+  const validation = useValidations(['userConfig']);
+  const state = usePartState(compareData(defaultConfig), compareData(config), validation);
+  const dirty = usePartDirty(compareData(initConfig), compareData(config));
+  return {
+    name: 'Editor',
+    state,
+    reset: { dirty, action: () => reset() },
+    content: <EditorPart />
+  };
+}
+
+const EditorPart = () => {
+  const { config, update } = useEditorData();
+  const { context } = useEditorContext();
+  const editorItems = useMeta('meta/program/editor', { context, type: config.javaClass }, []).data;
+
+  function isLabel(object: Widget): object is Label {
+    return 'text' in object;
+  }
+
+  function isScript(object: Widget): object is Script {
+    return 'requiredType' in object;
+  }
+
+  function isText(object: Widget): object is Text {
+    return !isLabel(object) && !isScript(object);
+  }
+
+  const renderWidgetComponent = (widget: Widget) => {
+    if (isLabel(widget)) {
+      const message = widget.text;
+
+      if (widget.multiline) {
+        const sentences = message.split('\n');
+        return (
+          <div className='info-text'>
+            {sentences.map((sentence, index) => (
+              <p key={index}>{sentence.trim()}</p>
+            ))}
+          </div>
+        );
+      } else {
+        return <div className='info-text'>{message}</div>;
+      }
+    }
+    if (isScript(widget)) {
+      return <ScriptInput type={widget.requiredType} value={config.userConfig} onChange={change => update('userConfig', change)} />;
+    }
+    if (isText(widget)) {
+      return <Input value={config.userConfig} onChange={change => update('userConfig', change)} />;
+    }
+    return null;
+  };
+
+  if (editorItems.length === 0) {
+    return <MessageText message={{ severity: 'WARNING', message: 'There is no editor for this bean' }} />;
+  }
+
+  return (
+    <>
+      {editorItems.map((widget, index) => (
+        <div key={index}>{renderWidgetComponent(widget)}</div>
+      ))}
+    </>
+  );
+};

--- a/packages/editor/src/components/parts/program/editor/useEditorData.ts
+++ b/packages/editor/src/components/parts/program/editor/useEditorData.ts
@@ -1,0 +1,32 @@
+import { ConfigDataContext, useConfigDataContext } from '../../../../context';
+import { EditorData } from '@axonivy/inscription-protocol';
+import { produce } from 'immer';
+import { DataUpdater } from '../../../../types/lambda';
+
+export function useEditorData(): ConfigDataContext<EditorData> & {
+  update: DataUpdater<EditorData>;
+  reset: () => void;
+} {
+  const { setConfig, ...config } = useConfigDataContext();
+
+  const update: DataUpdater<EditorData> = (field, value) => {
+    setConfig(
+      produce((draft: EditorData) => {
+        draft[field] = value;
+      })
+    );
+  };
+
+  const reset = () =>
+    setConfig(
+      produce(draft => {
+        draft.userConfig = config.initConfig.userConfig;
+      })
+    );
+
+  return {
+    ...config,
+    update,
+    reset
+  };
+}

--- a/packages/editor/src/components/parts/program/event/ProgramStartPart.test.tsx
+++ b/packages/editor/src/components/parts/program/event/ProgramStartPart.test.tsx
@@ -17,8 +17,6 @@ describe('StartPart', () => {
 
   test('empty data', async () => {
     renderPart();
-    await SelectUtil.assertEmpty();
-    //await SelectUtil.assertOptionsCount(1);
     await CollapsableUtil.assertClosed('Permission');
   });
 

--- a/packages/editor/src/test-utils/test-utils.tsx
+++ b/packages/editor/src/test-utils/test-utils.tsx
@@ -18,7 +18,9 @@ import {
   RestClient,
   RestResource,
   RestResourceMeta,
-  RestClientRequest
+  RestClientRequest,
+  Widget,
+  ProgramInterface
 } from '@axonivy/inscription-protocol';
 import { queries, Queries, render, renderHook, RenderHookOptions, RenderOptions } from '@testing-library/react';
 import { deepmerge } from 'deepmerge-ts';
@@ -62,6 +64,8 @@ type ContextHelperProps = {
     restResource?: DeepPartial<RestResource>;
     restResources?: RestResourceMeta[];
     restProperties?: string[];
+    javaClasses?: ProgramInterface[];
+    widgets?: Widget[];
   };
   editor?: { title?: string; readonly?: boolean };
 };
@@ -143,6 +147,10 @@ const ContextHelper = (
             return (args as RestClientRequest).clientId !== '' ? Promise.resolve(props.meta?.restResources ?? []) : Promise.resolve([]);
           case 'meta/rest/properties':
             return Promise.resolve(props.meta?.restProperties ?? []);
+          case 'meta/program/types':
+            return Promise.resolve(props.meta?.javaClasses ?? []);
+          case 'meta/program/editor':
+            return Promise.resolve(props.meta?.widgets ?? []);
           default:
             throw Error('mock meta path not programmed');
         }

--- a/packages/protocol/src/data/part-data.ts
+++ b/packages/protocol/src/data/part-data.ts
@@ -62,3 +62,5 @@ export type RestRequestData = Pick<ConfigData, 'method' | 'target' | 'body' | 'c
 export type ProgramInterfaceStartData = Pick<ConfigData, 'javaClass' | 'exceptionHandler' | 'timeout'>;
 
 export type EventData = Pick<ConfigData, 'javaClass' | 'eventId' | 'timeout'>;
+
+export type EditorData = Pick<ConfigData, 'userConfig' | 'javaClass'>;

--- a/packages/protocol/src/inscription-protocol.ts
+++ b/packages/protocol/src/inscription-protocol.ts
@@ -25,7 +25,9 @@ import {
   WebServiceClient,
   WebServiceClientRequest,
   WebServiceOperation,
-  WebServicePortRequest
+  WebServicePortRequest,
+  ProgramEditorRequest,
+  Widget
 } from './data/inscription';
 import { InscriptionData, InscriptionSaveData } from './data/inscription-data';
 
@@ -61,6 +63,7 @@ export interface InscriptionMetaRequestTypes {
   'meta/scripting/dataClasses': [InscriptionContext, DataClass[]];
 
   'meta/program/types': [ProgramInterfacesRequest, ProgramInterface[]];
+  'meta/program/editor': [ProgramEditorRequest, Widget[]];
 
   'meta/connector/out': [InscriptionContext, ConnectorRef[]];
 }


### PR DESCRIPTION
First simple version of the EditorPart.
I haven't really separated the component yet, nor have I created any unit or integration tests. I think since it is not 100% known how or what data I will get from the backend I should not invest too much time in testing and separating the current solution. what do you think?
I also tried to format the multiline-label-text using linebreaks similar to the current version but I'm not satisfied yet. The current texts are separated quite randomly at certain places with linebreaks, so the separation-expression for these texts could become extremely long and unattractive. maybe i could skip this part at the moment as well.