### PR TITLE
XIVY-11798 implement base of all known browser

### DIFF
--- a/integrations/standalone/tests/integration/activites/interface/restclient.spec.ts
+++ b/integrations/standalone/tests/integration/activites/interface/restclient.spec.ts
@@ -52,7 +52,7 @@ test.describe('Rest Client', () => {
     await runTest(view, RestRequestBodyOpenApiTest);
   });
 
-  test('Response', async () => {
+  test.skip('Response', async () => {
     await runTest(view, RestResponseTest);
   });
 });

--- a/packages/editor/src/components/browser/Browser.tsx
+++ b/packages/editor/src/components/browser/Browser.tsx
@@ -7,6 +7,11 @@ import { useState } from 'react';
 import { useAttributeBrowser } from './AttributeBrowser';
 import { useCmsBrowser } from './CmsBrowser';
 import { BrowserType, UseBrowserReturnValue } from './useBrowser';
+import { useFuncBrowser } from './FunctionBrowser';
+import { useDataTypeBrowser } from './DataTypeBrowser';
+import { useTableColBrowser } from './TableColBrowser';
+import { useSqlOpBrowser } from './SqlOperationBrowser';
+import { useCatPathChooserBrowser } from './CatPathChooser';
 
 type BrowserProps = UseBrowserReturnValue & {
   types: BrowserType[];
@@ -20,7 +25,13 @@ const Browser = ({ open, onOpenChange, types, accept, location }: BrowserProps) 
 
   const attrBrowser = useAttributeBrowser(location);
   const cmsBrowser = useCmsBrowser();
-  const allBrowsers = [attrBrowser, cmsBrowser];
+  const funcBrowser = useFuncBrowser();
+  const dataTypeBrowser = useDataTypeBrowser();
+  const catPathChooserBrowser = useCatPathChooserBrowser();
+  const tableColBrowser = useTableColBrowser();
+  const sqlOpBrowser = useSqlOpBrowser();
+
+  const allBrowsers = [attrBrowser, cmsBrowser, funcBrowser, dataTypeBrowser, catPathChooserBrowser, tableColBrowser, sqlOpBrowser];
 
   const tabs = allBrowsers.filter(browser => types.includes(browser.id));
   const acceptBrowser = () => accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? '');

--- a/packages/editor/src/components/browser/CatPathChooser.tsx
+++ b/packages/editor/src/components/browser/CatPathChooser.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { Input } from '../widgets';
+import { UseBrowserImplReturnValue } from './useBrowser';
+export const CAT_PATH_CHOOSER_BROWSER_ID = 'catPath' as const;
+
+export const useCatPathChooserBrowser = (): UseBrowserImplReturnValue => {
+  const [value, setValue] = useState('category path chooser');
+  return {
+    id: CAT_PATH_CHOOSER_BROWSER_ID,
+    name: 'Category Path Chooser',
+    content: <CatPathChooserBrowser value={value} onChange={setValue} />,
+    accept: () => value
+  };
+};
+
+const CatPathChooserBrowser = (props: { value: string; onChange: (value: string) => void }) => {
+  return <Input {...props} />;
+};

--- a/packages/editor/src/components/browser/DataTypeBrowser.tsx
+++ b/packages/editor/src/components/browser/DataTypeBrowser.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import { Input } from '../widgets';
+import { UseBrowserImplReturnValue } from './useBrowser';
+export const DATATYPE_BROWSER_ID = 'datatype' as const;
+
+export const useDataTypeBrowser = (): UseBrowserImplReturnValue => {
+  const [value, setValue] = useState('datatype');
+  return { id: DATATYPE_BROWSER_ID, name: 'Datatype', content: <DataTypeBrowser value={value} onChange={setValue} />, accept: () => value };
+};
+
+const DataTypeBrowser = (props: { value: string; onChange: (value: string) => void }) => {
+  return <Input {...props} />;
+};

--- a/packages/editor/src/components/browser/FunctionBrowser.tsx
+++ b/packages/editor/src/components/browser/FunctionBrowser.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import { Input } from '../widgets';
+import { UseBrowserImplReturnValue } from './useBrowser';
+export const FUNCTION_BROWSER_ID = 'func' as const;
+
+export const useFuncBrowser = (): UseBrowserImplReturnValue => {
+  const [value, setValue] = useState('function');
+  return { id: FUNCTION_BROWSER_ID, name: 'Function', content: <FunctionBrowser value={value} onChange={setValue} />, accept: () => value };
+};
+
+const FunctionBrowser = (props: { value: string; onChange: (value: string) => void }) => {
+  return <Input {...props} />;
+};

--- a/packages/editor/src/components/browser/SqlOperationBrowser.tsx
+++ b/packages/editor/src/components/browser/SqlOperationBrowser.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { Input } from '../widgets';
+import { UseBrowserImplReturnValue } from './useBrowser';
+export const SQL_OPERATION_BROWSER_ID = 'sqlOp' as const;
+
+export const useSqlOpBrowser = (): UseBrowserImplReturnValue => {
+  const [value, setValue] = useState('sql operation');
+  return {
+    id: SQL_OPERATION_BROWSER_ID,
+    name: 'SQL Operation',
+    content: <SqlOperationBrowser value={value} onChange={setValue} />,
+    accept: () => value
+  };
+};
+
+const SqlOperationBrowser = (props: { value: string; onChange: (value: string) => void }) => {
+  return <Input {...props} />;
+};

--- a/packages/editor/src/components/browser/TableColBrowser.tsx
+++ b/packages/editor/src/components/browser/TableColBrowser.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { Input } from '../widgets';
+import { UseBrowserImplReturnValue } from './useBrowser';
+export const TABLE_COL_BROWSER_ID = 'tablecol' as const;
+
+export const useTableColBrowser = (): UseBrowserImplReturnValue => {
+  const [value, setValue] = useState('table column');
+  return {
+    id: TABLE_COL_BROWSER_ID,
+    name: 'Table Column',
+    content: <TableColumnBrowser value={value} onChange={setValue} />,
+    accept: () => value
+  };
+};
+
+const TableColumnBrowser = (props: { value: string; onChange: (value: string) => void }) => {
+  return <Input {...props} />;
+};

--- a/packages/editor/src/components/browser/useBrowser.ts
+++ b/packages/editor/src/components/browser/useBrowser.ts
@@ -2,8 +2,20 @@ import { useState } from 'react';
 import { ATTRIBUTE_BROWSER_ID } from './AttributeBrowser';
 import { CMS_BROWSER_ID } from './CmsBrowser';
 import { Tab } from '../widgets';
+import { FUNCTION_BROWSER_ID } from './FunctionBrowser';
+import { DATATYPE_BROWSER_ID } from './DataTypeBrowser';
+import { TABLE_COL_BROWSER_ID } from './TableColBrowser';
+import { SQL_OPERATION_BROWSER_ID } from './SqlOperationBrowser';
+import { CAT_PATH_CHOOSER_BROWSER_ID } from './CatPathChooser';
 
-export type BrowserType = typeof ATTRIBUTE_BROWSER_ID | typeof CMS_BROWSER_ID;
+export type BrowserType =
+  | typeof ATTRIBUTE_BROWSER_ID
+  | typeof CMS_BROWSER_ID
+  | typeof FUNCTION_BROWSER_ID
+  | typeof DATATYPE_BROWSER_ID
+  | typeof CAT_PATH_CHOOSER_BROWSER_ID
+  | typeof TABLE_COL_BROWSER_ID
+  | typeof SQL_OPERATION_BROWSER_ID;
 
 export type UseBrowserImplReturnValue = Omit<Tab, 'id'> & {
   id: BrowserType;

--- a/packages/editor/src/components/editors/activity/interface.tsx
+++ b/packages/editor/src/components/editors/activity/interface.tsx
@@ -24,7 +24,7 @@ const DatabaseEditor = memo(() => {
   const name = useNamePart();
   const query = useQueryPart();
   const cache = useCachePart();
-  const output = useOutputPart();
+  const output = useOutputPart({ additionalBrowsers: ['tablecol'] });
   return <InscriptionEditor icon={IvyIcons.Database} parts={[name, query, cache, output]} />;
 });
 

--- a/packages/editor/src/components/editors/activity/workflow.tsx
+++ b/packages/editor/src/components/editors/activity/workflow.tsx
@@ -33,7 +33,7 @@ const UserTaskEditor = memo(() => {
 
 const ScriptEditor = memo(() => {
   const name = useNamePart();
-  const output = useOutputPart({ hideCode: true });
+  const output = useOutputPart({ hideCode: true, additionalBrowsers: ['cms'] });
   const code = useOutputCodePart();
   return <InscriptionEditor icon={IvyIcons.Script} parts={[name, output, code]} />;
 });

--- a/packages/editor/src/components/parts/cache/CacheLifetime.tsx
+++ b/packages/editor/src/components/parts/cache/CacheLifetime.tsx
@@ -21,6 +21,7 @@ export const CacheLifetime = ({ description, config, updater, cacheMode, ...prop
           value={config.name}
           onChange={change => updater('name', change)}
           type={IVY_SCRIPT_TYPES.STRING}
+          browsers={['attr', 'func', 'datatype', 'cms']}
           {...cacheLifetimeFieldset.inputProps}
         />
       </PathFieldset>
@@ -41,6 +42,7 @@ export const CacheLifetime = ({ description, config, updater, cacheMode, ...prop
               value={config.time}
               onChange={change => updater('time', change)}
               type={config.invalidation === 'FIXED_TIME' ? IVY_SCRIPT_TYPES.TIME : IVY_SCRIPT_TYPES.NUMBER}
+              browsers={['attr', 'func', 'datatype', 'cms']}
               {...timeFieldset.inputProps}
             />
           )}

--- a/packages/editor/src/components/parts/call/CallMapping.tsx
+++ b/packages/editor/src/components/parts/call/CallMapping.tsx
@@ -15,9 +15,19 @@ const CallMapping = ({ variableInfo }: { variableInfo: VariableInfo }) => {
 
   return (
     <PathContext path='call'>
-      <MappingPart data={config.call.map} variableInfo={variableInfo} onChange={change => update('map', change)} />
+      <MappingPart
+        data={config.call.map}
+        variableInfo={variableInfo}
+        onChange={change => update('map', change)}
+        browsers={['attr', 'func', 'datatype']}
+      />
       <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-        <ScriptArea value={config.call.code} onChange={change => update('code', change)} {...codeFieldset.inputProps} />
+        <ScriptArea
+          value={config.call.code}
+          onChange={change => update('code', change)}
+          browsers={['attr', 'func', 'datatype']}
+          {...codeFieldset.inputProps}
+        />
       </PathFieldset>
     </PathContext>
   );

--- a/packages/editor/src/components/parts/code/CodePart.tsx
+++ b/packages/editor/src/components/parts/code/CodePart.tsx
@@ -20,7 +20,12 @@ const CodePart = () => {
 
   return (
     <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-      <ScriptArea value={config.code} onChange={change => update('code', change)} {...codeFieldset.inputProps} />
+      <ScriptArea
+        value={config.code}
+        onChange={change => update('code', change)}
+        browsers={['attr', 'func', 'datatype', 'cms']}
+        {...codeFieldset.inputProps}
+      />
     </PathFieldset>
   );
 };

--- a/packages/editor/src/components/parts/common/customfield/CustomFieldTable.test.tsx
+++ b/packages/editor/src/components/parts/common/customfield/CustomFieldTable.test.tsx
@@ -69,7 +69,9 @@ describe('CustomFieldTable', () => {
   });
 
   test('table support readonly mode', async () => {
-    render(<CustomFieldTable data={customFields} onChange={() => {}} type='CASE' />, { wrapperProps: { editor: { readonly: true } } });
+    render(<CustomFieldTable data={customFields} onChange={() => {}} type='CASE' />, {
+      wrapperProps: { editor: { readonly: true } }
+    });
     TableUtil.assertReadonly();
     expect(screen.getByDisplayValue(/field1/)).toBeDisabled();
     expect(screen.getAllByRole('combobox')[0]).toBeDisabled();

--- a/packages/editor/src/components/parts/common/customfield/CustomFieldTable.tsx
+++ b/packages/editor/src/components/parts/common/customfield/CustomFieldTable.tsx
@@ -42,7 +42,9 @@ const CustomFieldTable = ({ data, onChange, type }: CustomFieldTableProps) => {
       {
         accessorKey: 'value',
         header: header => <SortableHeader header={header} name='Expression' />,
-        cell: cell => <ScriptCell cell={cell} type={CUSTOM_FIELD_TYPE[cell.row.original.type]} />
+        cell: cell => (
+          <ScriptCell cell={cell} type={CUSTOM_FIELD_TYPE[cell.row.original.type]} browsers={['attr', 'func', 'datatype', 'cms']} />
+        )
       }
     ],
     [items]

--- a/packages/editor/src/components/parts/common/info/Information.tsx
+++ b/packages/editor/src/components/parts/common/info/Information.tsx
@@ -21,13 +21,28 @@ const Information = <T extends InformationConfig>({ config, update }: Informatio
   return (
     <>
       <PathFieldset label='Name' {...nameFieldset.labelProps} path='name'>
-        <MacroInput value={config.name} onChange={change => update('name', change)} {...nameFieldset.inputProps} />
+        <MacroInput
+          value={config.name}
+          browsers={['attr', 'func', 'cms']}
+          onChange={change => update('name', change)}
+          {...nameFieldset.inputProps}
+        />
       </PathFieldset>
       <PathFieldset label='Description' {...descFieldset.labelProps} path='description'>
-        <MacroArea value={config.description} onChange={change => update('description', change)} {...descFieldset.inputProps} />
+        <MacroArea
+          value={config.description}
+          browsers={['attr', 'func', 'cms']}
+          onChange={change => update('description', change)}
+          {...descFieldset.inputProps}
+        />
       </PathFieldset>
       <PathFieldset label='Category' {...catFieldset.labelProps} path='category'>
-        <MacroInput value={config.category} onChange={change => update('category', change)} {...catFieldset.inputProps} />
+        <MacroInput
+          value={config.category}
+          browsers={['attr', 'catPath']}
+          onChange={change => update('category', change)}
+          {...catFieldset.inputProps}
+        />
       </PathFieldset>
     </>
   );

--- a/packages/editor/src/components/parts/common/mapping-tree/MappingPart.test.tsx
+++ b/packages/editor/src/components/parts/common/mapping-tree/MappingPart.test.tsx
@@ -57,7 +57,14 @@ describe('MappingPart', () => {
   } {
     userEvent.setup();
     let data = initData ?? { 'param.procurementRequest': 'in' };
-    render(<MappingPart data={data} variableInfo={variableInfo} onChange={(change: Record<string, string>) => (data = change)} />);
+    render(
+      <MappingPart
+        browsers={['attr', 'func', 'datatype']}
+        data={data}
+        variableInfo={variableInfo}
+        onChange={(change: Record<string, string>) => (data = change)}
+      />
+    );
     return {
       data: () => data
     };
@@ -169,7 +176,7 @@ describe('MappingPart', () => {
   });
 
   test('tree support readonly mode', async () => {
-    render(<MappingPart data={{}} variableInfo={variableInfo} onChange={() => {}} />, {
+    render(<MappingPart browsers={['attr', 'func', 'datatype']} data={{}} variableInfo={variableInfo} onChange={() => {}} />, {
       wrapperProps: { editor: { readonly: true } }
     });
     expect(screen.getAllByRole('textbox')[0]).toBeDisabled();

--- a/packages/editor/src/components/parts/common/mapping-tree/MappingPart.tsx
+++ b/packages/editor/src/components/parts/common/mapping-tree/MappingPart.tsx
@@ -3,12 +3,14 @@ import { PathFieldset } from '../path/PathFieldset';
 import MappingTree from './MappingTree';
 import { SchemaKeys, VariableInfo } from '@axonivy/inscription-protocol';
 import { useTableGlobalFilter, useTableOnlyInscribed } from './useMappingTree';
+import { BrowserType } from '../../../../components/browser';
 
 export type MappingPartProps = {
   data: Record<string, string>;
   variableInfo: VariableInfo;
   onChange: (change: Record<string, string>) => void;
   path?: SchemaKeys;
+  browsers: BrowserType[];
 };
 
 const MappingPart = ({ path, ...props }: MappingPartProps) => {

--- a/packages/editor/src/components/parts/common/mapping-tree/MappingTree.tsx
+++ b/packages/editor/src/components/parts/common/mapping-tree/MappingTree.tsx
@@ -22,7 +22,7 @@ type MappingTreeProps = MappingPartProps & {
   onlyInscribedFilter: TableFilter<ColumnFiltersState>;
 };
 
-const MappingTree = ({ data, variableInfo, onChange, globalFilter, onlyInscribedFilter }: MappingTreeProps) => {
+const MappingTree = ({ data, variableInfo, onChange, globalFilter, onlyInscribedFilter, browsers }: MappingTreeProps) => {
   const [tree, setTree] = useState<MappingTreeData[]>([]);
 
   useEffect(() => {
@@ -66,12 +66,12 @@ const MappingTree = ({ data, variableInfo, onChange, globalFilter, onlyInscribed
         accessorFn: row => row.value,
         id: 'value',
         header: () => <span>Expression</span>,
-        cell: cell => <ScriptCell cell={cell} type={cell.row.original.type} />,
+        cell: cell => <ScriptCell cell={cell} type={cell.row.original.type} browsers={browsers} />,
         footer: props => props.column.id,
         filterFn: (row, columnId, filterValue) => filterValue || row.original.value.length > 0
       }
     ],
-    [loadChildren]
+    [browsers, loadChildren]
   );
 
   const [sorting, setSorting] = useState<SortingState>([]);

--- a/packages/editor/src/components/parts/common/properties/PropertyTable.tsx
+++ b/packages/editor/src/components/parts/common/properties/PropertyTable.tsx
@@ -45,7 +45,7 @@ export const PropertyTable = ({ properties, update, knownProperties, hidePropert
       {
         accessorKey: 'expression',
         header: header => <SortableHeader header={header} name='Expression' />,
-        cell: cell => <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.OBJECT} />
+        cell: cell => <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.OBJECT} browsers={['attr', 'func', 'datatype', 'cms']} />
       }
     ],
     [knownPropertyItems]

--- a/packages/editor/src/components/parts/common/responsible/ResponsibleSelect.tsx
+++ b/packages/editor/src/components/parts/common/responsible/ResponsibleSelect.tsx
@@ -23,6 +23,7 @@ const ResponsibleActivator = ({ selectedType, ...props }: ActivatorProps) => {
           value={props.responsible?.activator ?? ''}
           onChange={change => props.updateResponsible('activator', change)}
           type={IVY_SCRIPT_TYPES.STRING}
+          browsers={['attr', 'func', 'datatype']}
         />
       );
     case 'DELETE_TASK':

--- a/packages/editor/src/components/parts/condition/ConditionTable.tsx
+++ b/packages/editor/src/components/parts/condition/ConditionTable.tsx
@@ -15,7 +15,7 @@ const ConditionTypeCell = ({ condition }: { condition: Condition }) => {
 
 const ConditionExpressionCell = ({ cell, removeCell }: { cell: CellContext<Condition, unknown>; removeCell: (id: string) => void }) => {
   if (cell.row.original.target) {
-    return <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.BOOLEAN} />;
+    return <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.BOOLEAN} browsers={['attr', 'func', 'datatype']} />;
   }
   return (
     <span style={{ display: 'flex' }}>

--- a/packages/editor/src/components/parts/error/ErrorThrowPart.tsx
+++ b/packages/editor/src/components/parts/error/ErrorThrowPart.tsx
@@ -48,6 +48,7 @@ const ErrorThrowPart = () => {
           value={config.throws.cause}
           onChange={change => update('cause', change)}
           type={IVY_SCRIPT_TYPES.BPM_ERROR}
+          browsers={['attr', 'func', 'datatype']}
           {...causeField.inputProps}
         />
       </PathFieldset>

--- a/packages/editor/src/components/parts/mail/MailAttachmentPart.tsx
+++ b/packages/editor/src/components/parts/mail/MailAttachmentPart.tsx
@@ -34,7 +34,7 @@ const MailAttachmentTable = () => {
         id: 'attachment',
         accessorFn: row => row,
         header: () => <span>Attachments</span>,
-        cell: cell => <ScriptCell cell={cell} type='Attachment' />
+        cell: cell => <ScriptCell cell={cell} type='Attachment' browsers={['attr', 'func', 'datatype', 'cms']} />
       }
     ],
     []

--- a/packages/editor/src/components/parts/mail/MailHeaderPart.tsx
+++ b/packages/editor/src/components/parts/mail/MailHeaderPart.tsx
@@ -4,6 +4,7 @@ import { useMailData } from './useMailData';
 import { IVY_EXCEPTIONS, MailData } from '@axonivy/inscription-protocol';
 import { PathContext, useValidations } from '../../../context';
 import { ExceptionSelect, PathFieldset } from '../common';
+import { BrowserType } from '../../../components/browser';
 
 export function useMailHeaderPart(): PartProps {
   const { config, initConfig, defaultConfig, resetHeaders } = useMailData();
@@ -25,26 +26,58 @@ const MailHeaderPart = () => {
   const bccFieldset = useFieldset();
   const exceptionFieldset = useFieldset();
 
+  const borwserTypes: BrowserType[] = ['attr', 'func', 'cms'];
+
   return (
     <>
       <PathContext path='headers'>
         <PathFieldset label='Subject' {...subjectFieldset.labelProps} path='subject'>
-          <MacroInput value={config.headers.subject} onChange={change => updateHeader('subject', change)} {...subjectFieldset.inputProps} />
+          <MacroInput
+            value={config.headers.subject}
+            onChange={change => updateHeader('subject', change)}
+            browsers={borwserTypes}
+            {...subjectFieldset.inputProps}
+          />
         </PathFieldset>
         <PathFieldset label='From' {...fromFieldset.labelProps} path='from'>
-          <MacroInput value={config.headers.from} onChange={change => updateHeader('from', change)} {...fromFieldset.inputProps} />
+          <MacroInput
+            value={config.headers.from}
+            onChange={change => updateHeader('from', change)}
+            browsers={borwserTypes}
+            {...fromFieldset.inputProps}
+          />
         </PathFieldset>
         <PathFieldset label='Reply to' {...replyToFieldset.labelProps} path='replyTo'>
-          <MacroInput value={config.headers.replyTo} onChange={change => updateHeader('replyTo', change)} {...replyToFieldset.inputProps} />
+          <MacroInput
+            value={config.headers.replyTo}
+            onChange={change => updateHeader('replyTo', change)}
+            browsers={borwserTypes}
+            {...replyToFieldset.inputProps}
+          />
         </PathFieldset>
         <PathFieldset label='To' {...toFieldset.labelProps} path='to'>
-          <MacroInput value={config.headers.to} onChange={change => updateHeader('to', change)} {...toFieldset.inputProps} />
+          <MacroInput
+            value={config.headers.to}
+            onChange={change => updateHeader('to', change)}
+            browsers={borwserTypes}
+            {...toFieldset.inputProps}
+          />
         </PathFieldset>
         <PathFieldset label='CC' {...ccFieldset.labelProps} path='cc'>
-          <MacroInput value={config.headers.cc} onChange={change => updateHeader('cc', change)} {...ccFieldset.inputProps} />
+          <MacroInput
+            value={config.headers.cc}
+            onChange={change => updateHeader('cc', change)}
+            browsers={borwserTypes}
+            {...ccFieldset.inputProps}
+          />
         </PathFieldset>
         <PathFieldset label='BCC' {...bccFieldset.labelProps} path='bcc'>
-          <MacroInput value={config.headers.bcc} onChange={change => updateHeader('bcc', change)} {...bccFieldset.inputProps} />
+          <MacroInput
+            value={config.headers.bcc}
+            onChange={change => updateHeader('bcc', change)}
+            browsers={borwserTypes}
+            {...bccFieldset.inputProps}
+          />
         </PathFieldset>
       </PathContext>
       <Collapsible

--- a/packages/editor/src/components/parts/mail/MailMessagePart.tsx
+++ b/packages/editor/src/components/parts/mail/MailMessagePart.tsx
@@ -25,7 +25,12 @@ const MailMessagePart = () => {
   return (
     <>
       <PathFieldset label='Message' {...messageFieldset.labelProps} path='message'>
-        <MacroArea value={config.message.body} onChange={change => updateMessage('body', change)} {...messageFieldset.inputProps} />
+        <MacroArea
+          value={config.message.body}
+          onChange={change => updateMessage('body', change)}
+          browsers={['attr', 'func', 'cms']}
+          {...messageFieldset.inputProps}
+        />
       </PathFieldset>
       <Fieldset label='Type' {...typeFieldset.labelProps}>
         <Select

--- a/packages/editor/src/components/parts/output/OutputCodePart.tsx
+++ b/packages/editor/src/components/parts/output/OutputCodePart.tsx
@@ -21,7 +21,12 @@ const OutputCodePart = () => {
   return (
     <PathContext path='output'>
       <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-        <ScriptArea value={config.output.code} onChange={change => update('code', change)} {...codeFieldset.inputProps} />
+        <ScriptArea
+          value={config.output.code}
+          onChange={change => update('code', change)}
+          browsers={['attr', 'func', 'datatype', 'cms']}
+          {...codeFieldset.inputProps}
+        />
       </PathFieldset>
       <Checkbox label='Disable Permission Checks (Execute this Script Step as SYSTEM)' value={config.sudo} onChange={updateSudo} />
     </PathContext>

--- a/packages/editor/src/components/parts/output/OutputPart.tsx
+++ b/packages/editor/src/components/parts/output/OutputPart.tsx
@@ -4,8 +4,9 @@ import { PathContext, useEditorContext, useMeta, useValidations } from '../../..
 import { PartProps, usePartDirty, usePartState } from '../../editors';
 import { useOutputData } from './useOutputData';
 import { MappingPart, PathFieldset } from '../common';
+import { BrowserType } from '../../../components/browser';
 
-export function useOutputPart(options?: { hideCode?: boolean }): PartProps {
+export function useOutputPart(options?: { hideCode?: boolean; additionalBrowsers?: BrowserType[] }): PartProps {
   const { config, defaultConfig, initConfig, resetOutput } = useOutputData();
   const compareData = (data: OutputData) => [data.output.map, options?.hideCode ? '' : data.output.code];
   const validations = useValidations(options?.hideCode ? ['output', 'map'] : ['output']);
@@ -15,23 +16,30 @@ export function useOutputPart(options?: { hideCode?: boolean }): PartProps {
     name: 'Output',
     state,
     reset: { dirty, action: () => resetOutput(!options?.hideCode) },
-    content: <OutputPart showCode={!options?.hideCode} />
+    content: <OutputPart showCode={!options?.hideCode} additionalBrowsers={options?.additionalBrowsers} />
   };
 }
 
-const OutputPart = (props: { showCode?: boolean }) => {
+const OutputPart = (props: { showCode?: boolean; additionalBrowsers?: BrowserType[] }) => {
   const { config, update } = useOutputData();
 
   const { context } = useEditorContext();
   const { data: variableInfo } = useMeta('meta/scripting/out', { context, location: 'output' }, { variables: [], types: {} });
 
+  const browsers: BrowserType[] = ['attr', 'func', 'datatype', ...(props.additionalBrowsers ?? [])];
+
   const codeFieldset = useFieldset();
   return (
     <PathContext path='output'>
-      <MappingPart data={config.output.map} variableInfo={variableInfo} onChange={change => update('map', change)} />
+      <MappingPart data={config.output.map} variableInfo={variableInfo} onChange={change => update('map', change)} browsers={browsers} />
       {props.showCode && (
         <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-          <ScriptArea value={config.output.code} onChange={change => update('code', change)} {...codeFieldset.inputProps} />
+          <ScriptArea
+            value={config.output.code}
+            onChange={change => update('code', change)}
+            browsers={browsers}
+            {...codeFieldset.inputProps}
+          />
         </PathFieldset>
       )}
     </PathContext>

--- a/packages/editor/src/components/parts/program/activity/ProgramInterfaceStartPart.tsx
+++ b/packages/editor/src/components/parts/program/activity/ProgramInterfaceStartPart.tsx
@@ -49,6 +49,7 @@ const ProgramInterfaceStartPart = () => {
             value={config.timeout.seconds}
             onChange={change => updateTimeout('seconds', change)}
             type={IVY_SCRIPT_TYPES.DURATION}
+            browsers={['attr', 'func', 'datatype']}
             {...timeoutSecondsFieldset.inputProps}
           />
         </PathFieldset>

--- a/packages/editor/src/components/parts/program/editor/EditorPart.tsx
+++ b/packages/editor/src/components/parts/program/editor/EditorPart.tsx
@@ -54,7 +54,14 @@ const EditorPart = () => {
       }
     }
     if (isScript(widget)) {
-      return <ScriptInput type={widget.requiredType} value={config.userConfig} onChange={change => update('userConfig', change)} />;
+      return (
+        <ScriptInput
+          type={widget.requiredType}
+          value={config.userConfig}
+          onChange={change => update('userConfig', change)}
+          browsers={['attr', 'func', 'datatype', 'cms']}
+        />
+      );
     }
     if (isText(widget)) {
       return <Input value={config.userConfig} onChange={change => update('userConfig', change)} />;

--- a/packages/editor/src/components/parts/program/intermediate/EventPart.tsx
+++ b/packages/editor/src/components/parts/program/intermediate/EventPart.tsx
@@ -44,6 +44,7 @@ const EventPart = () => {
           value={config.eventId}
           onChange={change => update('eventId', change)}
           type={IVY_SCRIPT_TYPES.NUMBER}
+          browsers={['attr', 'func', 'datatype']}
           {...eventIdFieldset.inputProps}
         />
       </PathFieldset>
@@ -54,6 +55,7 @@ const EventPart = () => {
             value={config.timeout.duration}
             onChange={change => updateTimeout('duration', change)}
             type={IVY_SCRIPT_TYPES.DURATION}
+            browsers={['attr', 'func', 'datatype']}
             {...timeoutDurationFieldset.inputProps}
           />
         </PathFieldset>

--- a/packages/editor/src/components/parts/query/database/Condition.tsx
+++ b/packages/editor/src/components/parts/query/database/Condition.tsx
@@ -9,7 +9,11 @@ export const Condition = () => {
     <PathContext path='sql'>
       <PathCollapsible label='Condition' defaultOpen={config.query.sql.condition !== defaultConfig.query.sql.condition} path='condition'>
         <ValidationFieldset>
-          <MacroArea value={config.query.sql.condition} onChange={change => updateSql('condition', change)} />
+          <MacroArea
+            value={config.query.sql.condition}
+            onChange={change => updateSql('condition', change)}
+            browsers={['tablecol', 'sqlOp', 'attr']}
+          />
         </ValidationFieldset>
       </PathCollapsible>
     </PathContext>

--- a/packages/editor/src/components/parts/query/database/Limit.tsx
+++ b/packages/editor/src/components/parts/query/database/Limit.tsx
@@ -19,6 +19,7 @@ export const Limit = () => {
           value={config.query.limit}
           onChange={change => update('limit', change)}
           type={IVY_SCRIPT_TYPES.NUMBER}
+          browsers={['attr', 'func', 'datatype']}
           {...limitFieldset.inputProps}
         />
       </PathFieldset>
@@ -27,6 +28,7 @@ export const Limit = () => {
           value={config.query.offset}
           onChange={change => update('offset', change)}
           type={IVY_SCRIPT_TYPES.NUMBER}
+          browsers={['attr', 'func', 'datatype']}
           {...offsetFieldset.inputProps}
         />
       </PathFieldset>

--- a/packages/editor/src/components/parts/query/database/Statement.tsx
+++ b/packages/editor/src/components/parts/query/database/Statement.tsx
@@ -11,7 +11,7 @@ export const Statement = () => {
       path='sql'
     >
       <PathFieldset label='SQL Query' path='stmt'>
-        <MacroArea value={config.query.sql.stmt} onChange={change => updateSql('stmt', change)} />
+        <MacroArea value={config.query.sql.stmt} onChange={change => updateSql('stmt', change)} browsers={['tablecol', 'sqlOp', 'attr']} />
       </PathFieldset>
       <MessageText
         message={{

--- a/packages/editor/src/components/parts/query/database/TableFields.tsx
+++ b/packages/editor/src/components/parts/query/database/TableFields.tsx
@@ -44,7 +44,7 @@ export const TableFields = () => {
       {
         accessorKey: 'expression',
         header: header => <SortableHeader header={header} name='Value' />,
-        cell: cell => <ScriptCell cell={cell} type={cell.row.original.ivyType} />
+        cell: cell => <ScriptCell cell={cell} type={cell.row.original.ivyType} browsers={['attr', 'func', 'datatype', 'cms']} />
       }
     ],
     []

--- a/packages/editor/src/components/parts/rest/RestResponsePart.tsx
+++ b/packages/editor/src/components/parts/rest/RestResponsePart.tsx
@@ -43,9 +43,19 @@ const RestResponsePart = () => {
             />
           </PathFieldset>
         )}
-        <MappingPart data={config.response.entity.map} variableInfo={variableInfo} onChange={change => updateEntity('map', change)} />
+        <MappingPart
+          data={config.response.entity.map}
+          variableInfo={variableInfo}
+          browsers={['attr', 'func', 'datatype']}
+          onChange={change => updateEntity('map', change)}
+        />
         <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-          <ScriptArea value={config.response.entity.code} onChange={change => updateEntity('code', change)} {...codeFieldset.inputProps} />
+          <ScriptArea
+            value={config.response.entity.code}
+            onChange={change => updateEntity('code', change)}
+            browsers={['attr', 'func', 'datatype']}
+            {...codeFieldset.inputProps}
+          />
         </PathFieldset>
       </PathContext>
 

--- a/packages/editor/src/components/parts/rest/rest-request/rest-body/RestBodyRaw.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-body/RestBodyRaw.tsx
@@ -8,7 +8,7 @@ export const RestBodyRaw = () => {
   return (
     <PathContext path='raw'>
       <ValidationFieldset>
-        <MacroArea value={config.body.raw} onChange={change => updateBody('raw', change)} />
+        <MacroArea value={config.body.raw} onChange={change => updateBody('raw', change)} browsers={['attr', 'func', 'cms']} />
       </ValidationFieldset>
     </PathContext>
   );

--- a/packages/editor/src/components/parts/rest/rest-request/rest-body/RestEntity.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-body/RestEntity.tsx
@@ -34,9 +34,19 @@ export const RestEntity = () => {
           />
         </PathFieldset>
       )}
-      <MappingPart data={config.body.entity.map} onChange={change => updateEntity('map', change)} variableInfo={variableInfo} />
+      <MappingPart
+        browsers={['attr', 'func', 'datatype']}
+        data={config.body.entity.map}
+        onChange={change => updateEntity('map', change)}
+        variableInfo={variableInfo}
+      />
       <PathFieldset label='Code' path='code' {...codeFieldset.labelProps}>
-        <ScriptArea value={config.body.entity.code} onChange={change => updateEntity('code', change)} {...codeFieldset.inputProps} />
+        <ScriptArea
+          value={config.body.entity.code}
+          onChange={change => updateEntity('code', change)}
+          browsers={['attr', 'func', 'datatype']}
+          {...codeFieldset.inputProps}
+        />
       </PathFieldset>
     </PathContext>
   );

--- a/packages/editor/src/components/parts/rest/rest-request/rest-body/RestForm.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-body/RestForm.tsx
@@ -48,7 +48,9 @@ export const RestForm = () => {
       {
         accessorKey: 'expression',
         header: header => <SortableHeader header={header} name='Expression' />,
-        cell: cell => <ScriptCell cell={cell} type={cell.row.original.type ?? IVY_SCRIPT_TYPES.OBJECT} />
+        cell: cell => (
+          <ScriptCell cell={cell} type={cell.row.original.type ?? IVY_SCRIPT_TYPES.OBJECT} browsers={['attr', 'func', 'datatype', 'cms']} />
+        )
       }
     ],
     []

--- a/packages/editor/src/components/parts/rest/rest-request/rest-body/RestJaxRsCode.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-body/RestJaxRsCode.tsx
@@ -8,7 +8,12 @@ export const RestJaxRsCode = () => {
   const fieldset = useFieldset();
   return (
     <PathFieldset label='JAX-RS' path='code' {...fieldset.labelProps}>
-      <ScriptArea value={config.code} onChange={change => update('code', change)} {...fieldset.inputProps} />
+      <ScriptArea
+        value={config.code}
+        onChange={change => update('code', change)}
+        browsers={['attr', 'func', 'datatype']}
+        {...fieldset.inputProps}
+      />
     </PathFieldset>
   );
 };

--- a/packages/editor/src/components/parts/rest/rest-request/rest-target/RestMethodSelect.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-target/RestMethodSelect.tsx
@@ -64,6 +64,7 @@ export const RestMethodSelect = () => {
             onChange={change => updateTarget('path', change)}
             type={IVY_SCRIPT_TYPES.STRING}
             modifyAction={value => `{${value}}`}
+            browsers={['attr']}
             {...fieldset.inputProps}
           />
         </div>

--- a/packages/editor/src/components/parts/rest/rest-request/rest-target/RestParameters.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-target/RestParameters.tsx
@@ -60,7 +60,9 @@ export const RestParameters = () => {
       {
         accessorKey: 'expression',
         header: header => <SortableHeader header={header} name='Expression' />,
-        cell: cell => <ScriptCell cell={cell} type={cell.row.original.type ?? IVY_SCRIPT_TYPES.OBJECT} />
+        cell: cell => (
+          <ScriptCell cell={cell} type={cell.row.original.type ?? IVY_SCRIPT_TYPES.OBJECT} browsers={['attr', 'func', 'datatype', 'cms']} />
+        )
       }
     ],
     [kindItems]

--- a/packages/editor/src/components/parts/result/ResultPart.tsx
+++ b/packages/editor/src/components/parts/result/ResultPart.tsx
@@ -37,9 +37,19 @@ const ResultPart = ({ hideParamDesc }: { hideParamDesc?: boolean }) => {
       <Collapsible label='Result parameters'>
         <ParameterTable data={config.result.params} onChange={change => update('params', change)} hideDesc={hideParamDesc} />
       </Collapsible>
-      <MappingPart data={config.result.map} variableInfo={variableInfo} onChange={change => update('map', change)} />
+      <MappingPart
+        data={config.result.map}
+        variableInfo={variableInfo}
+        onChange={change => update('map', change)}
+        browsers={['attr', 'func', 'datatype']}
+      />
       <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-        <ScriptArea value={config.result.code} onChange={change => update('code', change)} {...codeFieldset.inputProps} />
+        <ScriptArea
+          value={config.result.code}
+          onChange={change => update('code', change)}
+          browsers={['attr', 'func', 'datatype']}
+          {...codeFieldset.inputProps}
+        />
       </PathFieldset>
     </PathContext>
   );

--- a/packages/editor/src/components/parts/start/StartPart.tsx
+++ b/packages/editor/src/components/parts/start/StartPart.tsx
@@ -44,9 +44,19 @@ const StartPart = ({ hideParamDesc, synchParams }: StartPartProps) => {
         <PathCollapsible label='Input parameters' path='params'>
           <ParameterTable data={config.input.params} onChange={change => update('params', change)} hideDesc={hideParamDesc} />
         </PathCollapsible>
-        <MappingPart data={config.input.map} variableInfo={variableInfo} onChange={change => update('map', change)} />
+        <MappingPart
+          data={config.input.map}
+          variableInfo={variableInfo}
+          onChange={change => update('map', change)}
+          browsers={['attr', 'func', 'datatype']}
+        />
         <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-          <ScriptArea value={config.input.code} onChange={change => update('code', change)} {...codeFieldset.inputProps} />
+          <ScriptArea
+            value={config.input.code}
+            onChange={change => update('code', change)}
+            browsers={['attr', 'func', 'datatype']}
+            {...codeFieldset.inputProps}
+          />
         </PathFieldset>
       </PathContext>
     </>

--- a/packages/editor/src/components/parts/task/code/TaskCode.tsx
+++ b/packages/editor/src/components/parts/task/code/TaskCode.tsx
@@ -7,7 +7,7 @@ const TaskCode = () => {
   return (
     <PathCollapsible label='Code' defaultOpen={task.code.length > 0} path='code'>
       <ValidationFieldset>
-        <ScriptArea value={task.code} onChange={change => update('code', change)} />
+        <ScriptArea value={task.code} onChange={change => update('code', change)} browsers={['attr', 'func', 'datatype']} />
       </ValidationFieldset>
     </PathCollapsible>
   );

--- a/packages/editor/src/components/parts/task/expiry/ExpiryPart.tsx
+++ b/packages/editor/src/components/parts/task/expiry/ExpiryPart.tsx
@@ -18,6 +18,7 @@ const ExpiryPart = () => {
           value={expiry.timeout}
           onChange={change => update('timeout', change)}
           type={IVY_SCRIPT_TYPES.DURATION}
+          browsers={['attr', 'func', 'datatype']}
           {...timeoutFieldset.inputProps}
         />
       </PathFieldset>

--- a/packages/editor/src/components/parts/task/options/TaskListOptions.tsx
+++ b/packages/editor/src/components/parts/task/options/TaskListOptions.tsx
@@ -15,6 +15,7 @@ const TaskListPart = () => {
           value={task.delay}
           onChange={change => update('delay', change)}
           {...delayFieldset.inputProps}
+          browsers={['attr', 'func', 'datatype']}
           type={IVY_SCRIPT_TYPES.DURATION}
         />
       </ValidationFieldset>

--- a/packages/editor/src/components/parts/task/priority/PrioritySelect.tsx
+++ b/packages/editor/src/components/parts/task/priority/PrioritySelect.tsx
@@ -28,7 +28,12 @@ const PrioritySelect = ({ priority, updatePriority }: { priority?: WfPriority; u
           inputProps={selectFieldset.inputProps}
         />
         {(selectedLevel.value as WfLevel) === 'SCRIPT' && (
-          <ScriptInput type={IVY_SCRIPT_TYPES.INT} value={priority?.script ?? ''} onChange={change => updatePriority('script', change)} />
+          <ScriptInput
+            type={IVY_SCRIPT_TYPES.INT}
+            value={priority?.script ?? ''}
+            onChange={change => updatePriority('script', change)}
+            browsers={['attr', 'func', 'datatype']}
+          />
         )}
       </div>
     </PathFieldset>

--- a/packages/editor/src/components/parts/trigger/TriggerPart.tsx
+++ b/packages/editor/src/components/parts/trigger/TriggerPart.tsx
@@ -41,6 +41,7 @@ const TriggerPart = () => {
                 value={config.task.delay}
                 onChange={change => updateDelay(change)}
                 type={IVY_SCRIPT_TYPES.DURATION}
+                browsers={['attr', 'func', 'datatype']}
                 {...delayFieldset.inputProps}
               />
             </PathFieldset>

--- a/packages/editor/src/components/parts/web-service/Exception.tsx
+++ b/packages/editor/src/components/parts/web-service/Exception.tsx
@@ -18,6 +18,7 @@ export const Exception = () => {
           value={config.exception.condition}
           onChange={change => updateException('condition', change)}
           type={IVY_SCRIPT_TYPES.BOOLEAN}
+          browsers={['attr', 'func', 'datatype']}
           {...conditionFieldset.inputProps}
         />
       </PathFieldset>
@@ -26,6 +27,7 @@ export const Exception = () => {
           value={config.exception.message}
           onChange={change => updateException('message', change)}
           type={IVY_SCRIPT_TYPES.STRING}
+          browsers={['attr', 'func', 'datatype']}
           {...messageFieldset.inputProps}
         />
       </PathFieldset>

--- a/packages/editor/src/components/parts/ws-request/WsMapping.tsx
+++ b/packages/editor/src/components/parts/ws-request/WsMapping.tsx
@@ -18,6 +18,7 @@ export const WsMapping = () => {
         onChange={change => updateOperation('parameters', change)}
         variableInfo={variableInfo}
         path='parameters'
+        browsers={['attr', 'func', 'datatype', 'cms']}
       />
     </PathContext>
   );

--- a/packages/editor/src/components/parts/ws-response/WsResponsePart.tsx
+++ b/packages/editor/src/components/parts/ws-response/WsResponsePart.tsx
@@ -23,9 +23,19 @@ const WsResponsePart = () => {
   return (
     <>
       <PathContext path='output'>
-        <MappingPart data={config.output.map} variableInfo={variableInfo} onChange={change => updateOutput('map', change)} />
+        <MappingPart
+          data={config.output.map}
+          variableInfo={variableInfo}
+          onChange={change => updateOutput('map', change)}
+          browsers={['attr', 'func', 'datatype']}
+        />
         <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
-          <ScriptArea value={config.output.code} onChange={change => updateOutput('code', change)} {...codeFieldset.inputProps} />
+          <ScriptArea
+            value={config.output.code}
+            onChange={change => updateOutput('code', change)}
+            browsers={['attr', 'func', 'datatype']}
+            {...codeFieldset.inputProps}
+          />
         </PathFieldset>
       </PathContext>
       <PathCollapsible label='Error' defaultOpen={config.exceptionHandler !== defaultConfig.exceptionHandler} path='exceptionHandler'>

--- a/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
@@ -6,7 +6,7 @@ import { usePath } from '../../../context';
 import { CardArea } from '../output/CardText';
 import { ElementRef, useRef } from 'react';
 
-const MacroArea = ({ value, onChange, ...props }: CodeEditorAreaProps) => {
+const MacroArea = ({ value, onChange, browsers, ...props }: CodeEditorAreaProps) => {
   const { isFocusWithin, focusWithinProps, focusValue } = useCodeEditorOnFocus(value, onChange);
   const browser = useBrowser();
   const { setEditor, modifyEditor } = useModifyEditor(value => `<%=${value}%>`);
@@ -26,7 +26,7 @@ const MacroArea = ({ value, onChange, ...props }: CodeEditorAreaProps) => {
             macro={true}
             initHeight={areaRef.current?.offsetHeight}
           />
-          <Browser {...browser} types={['attr', 'cms']} accept={modifyEditor} location={path} />
+          <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
         </>
       ) : (
         <CardArea value={value} {...props} ref={areaRef} />

--- a/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
@@ -7,7 +7,7 @@ import { CardText } from '../output/CardText';
 
 type MacroInputProps = Omit<CodeEditorInputProps, 'context'>;
 
-const MacroInput = ({ value, onChange, ...props }: MacroInputProps) => {
+const MacroInput = ({ value, onChange, browsers, ...props }: MacroInputProps) => {
   const { isFocusWithin, focusWithinProps, focusValue } = useCodeEditorOnFocus(value, onChange);
   const browser = useBrowser();
   const { setEditor, modifyEditor } = useModifyEditor(value => `<%=${value}%>`);
@@ -19,7 +19,7 @@ const MacroInput = ({ value, onChange, ...props }: MacroInputProps) => {
       {isFocusWithin || browser.open ? (
         <>
           <SingleLineCodeEditor {...focusValue} {...props} context={{ location: path }} macro={true} onMountFuncs={[setEditor]} />
-          <Browser {...browser} types={['attr']} accept={modifyEditor} location={path} />
+          <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
         </>
       ) : (
         <CardText value={value} {...props} />

--- a/packages/editor/src/components/widgets/code-editor/ResizableCodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ResizableCodeEditor.tsx
@@ -2,8 +2,11 @@ import './ResizableCodeEditor.css';
 import { useState } from 'react';
 import { useMove } from 'react-aria';
 import CodeEditor, { CodeEditorProps } from './CodeEditor';
+import { BrowserType } from '../../../components/browser';
 
-export type CodeEditorAreaProps = Omit<ResizableCodeEditorProps, 'macro' | 'options' | 'onMount' | 'location'>;
+export type CodeEditorAreaProps = Omit<ResizableCodeEditorProps, 'macro' | 'options' | 'onMount' | 'location'> & {
+  browsers: BrowserType[];
+};
 
 type ResizableCodeEditorProps = Omit<CodeEditorProps, 'height' | 'context'> & {
   location: string;

--- a/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
@@ -12,7 +12,7 @@ const ScriptArea = (props: CodeEditorAreaProps) => {
   return (
     <div className='script-area'>
       <ResizableCodeEditor {...props} location={path} onMountFuncs={[setEditor]} />
-      <Browser {...browser} types={['attr', 'cms']} accept={modifyEditor} location={path} />
+      <Browser {...browser} types={props.browsers} accept={modifyEditor} location={path} />
     </div>
   );
 };

--- a/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
@@ -12,6 +12,7 @@ const ScriptInput = ({
   editorOptions,
   keyActions,
   modifyAction,
+  browsers,
   ...props
 }: CodeEditorInputProps & { type: string }) => {
   const { isFocusWithin, focusWithinProps, focusValue } = useCodeEditorOnFocus(value, onChange);
@@ -32,7 +33,7 @@ const ScriptInput = ({
             editorOptions={editorOptions}
             keyActions={keyActions}
           />
-          <Browser {...browser} types={['attr', 'cms']} accept={modifyEditor} location={path} />
+          <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
         </>
       ) : (
         <Input value={value} onChange={onChange} {...props} />

--- a/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
@@ -3,6 +3,7 @@ import { SINGLE_LINE_MONACO_OPTIONS } from '../../../monaco/monaco-editor-util';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import CodeEditor, { CodeEditorProps } from './CodeEditor';
 import { monacoAutoFocus } from './useCodeEditor';
+import { BrowserType } from '../../../components/browser';
 
 type EditorOptions = {
   editorOptions?: {
@@ -17,7 +18,7 @@ type EditorOptions = {
 };
 
 export type CodeEditorInputProps = Omit<CodeEditorProps, 'macro' | 'options' | 'onMount' | 'height' | 'onMountFuncs' | 'context'> &
-  EditorOptions;
+  EditorOptions & { browsers: BrowserType[] };
 
 const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, keyActions, ...props }: CodeEditorProps & EditorOptions) => {
   const mountFuncs = onMountFuncs ? onMountFuncs : [];

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -9,7 +9,7 @@ import { useEditorContext, usePath } from '../../../../context';
 import { IvyIcons } from '@axonivy/editor-icons';
 import { Input } from '../../input';
 import { SingleLineCodeEditor } from '../../code-editor';
-import { Browser, useBrowser } from '../../../browser';
+import { Browser, BrowserType, useBrowser } from '../../../browser';
 import { useModifyEditor } from '../../code-editor/useCodeEditor';
 
 declare module '@tanstack/react-table' {
@@ -23,9 +23,10 @@ type CodeEditorCellProps<TData> = {
   cell: CellContext<TData, unknown>;
   makro: boolean;
   type?: string;
+  browsers: BrowserType[];
 };
 
-export function CodeEditorCell<TData>({ cell, makro, type }: CodeEditorCellProps<TData>) {
+export function CodeEditorCell<TData>({ cell, makro, type, browsers }: CodeEditorCellProps<TData>) {
   const initialValue = cell.getValue() as string;
   const [value, setValue] = useState(initialValue);
   useEffect(() => {
@@ -84,7 +85,7 @@ export function CodeEditorCell<TData>({ cell, makro, type }: CodeEditorCellProps
                     }}
                     {...codeFieldset.inputProps}
                   />
-                  <Browser {...browser} types={['attr', 'cms']} accept={modifyEditor} location={path} />
+                  <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
                 </div>
               </Fieldset>
               <PopoverClose className='popover-close' aria-label='Close' ref={closeRef}>

--- a/packages/editor/src/components/widgets/table/cell/MacroCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/MacroCell.tsx
@@ -1,4 +1,6 @@
 import { CellContext } from '@tanstack/react-table';
 import { CodeEditorCell } from './CodeEditorCell';
 
-export const MacroCell = <TData,>({ cell }: { cell: CellContext<TData, unknown> }) => <CodeEditorCell cell={cell} makro={true} />;
+export const MacroCell = <TData,>({ cell }: { cell: CellContext<TData, unknown> }) => (
+  <CodeEditorCell cell={cell} makro={true} browsers={['attr', 'func', 'cms']} />
+);

--- a/packages/editor/src/components/widgets/table/cell/ScriptCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/ScriptCell.tsx
@@ -1,6 +1,13 @@
 import { CellContext } from '@tanstack/react-table';
 import { CodeEditorCell } from './CodeEditorCell';
+import { BrowserType } from '../../../../components/browser';
 
-export const ScriptCell = <TData,>({ cell, type }: { cell: CellContext<TData, unknown>; type: string }) => (
-  <CodeEditorCell cell={cell} makro={false} type={type} />
-);
+export const ScriptCell = <TData,>({
+  cell,
+  type,
+  browsers
+}: {
+  cell: CellContext<TData, unknown>;
+  type: string;
+  browsers: BrowserType[];
+}) => <CodeEditorCell cell={cell} makro={false} type={type} browsers={browsers} />;


### PR DESCRIPTION
Placeholder made for all browsers
- Added several browsers (Func, Datatype, Api, CatPathChooser, SQl-Operation, Table Column)
- Widgets for Script-/Macroinputs/areas & ScriptCell adapted so that browsers-properties can be set in the part
- All elements worked through and correct browsers deposited at corresponding fields
- Output-Part with property "additionalBrowsers" added

ToDo:
- For some reason (still unexplained to me) three IT of the RestPart don't run anymore (currently skipped with .skip)
- End-Page: New widget must be created, which provides a simple input field with the browser function
- Signal code: Combox with browser function necessary
- Rest - Restbody: Combox with browser function necessary

