### PR TITLE
Add browser to rest signal

### DIFF
--- a/packages/editor/src/components/parts/common/eventcode/EventCodeSelect.tsx
+++ b/packages/editor/src/components/parts/common/eventcode/EventCodeSelect.tsx
@@ -1,6 +1,7 @@
 import { EventCodeMeta } from '@axonivy/inscription-protocol';
 import { Combobox, ComboboxItem, FieldsetInputProps, IvyIcon } from '../../../widgets';
 import { IvyIcons } from '@axonivy/editor-icons';
+import ComboboxWithBrowser from '../../../../components/widgets/combobox/ComboboxWithBrowser';
 
 export type EventCodeItem = Pick<EventCodeMeta, 'eventCode'> & { info?: string } & ComboboxItem;
 
@@ -10,9 +11,10 @@ type EventCodeSelectProps = {
   eventCodes: EventCodeItem[];
   eventIcon: IvyIcons;
   comboboxInputProps?: FieldsetInputProps;
+  withBrowser?: boolean;
 };
 
-const EventCodeSelect = ({ eventCode, onChange, eventCodes, eventIcon, comboboxInputProps }: EventCodeSelectProps) => {
+const EventCodeSelect = ({ eventCode, onChange, eventCodes, eventIcon, comboboxInputProps, withBrowser }: EventCodeSelectProps) => {
   const comboboxItem = (item: EventCodeItem) => {
     return (
       <>
@@ -29,7 +31,18 @@ const EventCodeSelect = ({ eventCode, onChange, eventCodes, eventIcon, comboboxI
     );
   };
 
-  return <Combobox value={eventCode} onChange={onChange} items={eventCodes} comboboxItem={comboboxItem} {...comboboxInputProps} />;
+  return withBrowser ? (
+    <ComboboxWithBrowser
+      browsers={['attr']}
+      value={eventCode}
+      onChange={onChange}
+      items={eventCodes}
+      comboboxItem={comboboxItem}
+      {...comboboxInputProps}
+    />
+  ) : (
+    <Combobox value={eventCode} onChange={onChange} items={eventCodes} comboboxItem={comboboxItem} {...comboboxInputProps} />
+  );
 };
 
 export default EventCodeSelect;

--- a/packages/editor/src/components/parts/rest/RestEntityTypeCombobox.tsx
+++ b/packages/editor/src/components/parts/rest/RestEntityTypeCombobox.tsx
@@ -1,7 +1,8 @@
 import { useOpenApi } from '../../../context';
-import { Combobox, ComboboxItem, FieldsetInputProps } from '../../../components/widgets';
+import { ComboboxItem, FieldsetInputProps } from '../../../components/widgets';
 import { RestPayload } from '@axonivy/inscription-protocol';
 import { typesSupportBinary } from './known-types';
+import ComboboxWithBrowser from '../../../components/widgets/combobox/ComboboxWithBrowser';
 
 type RestEntityTypeComboboxProps = FieldsetInputProps & {
   value: string;
@@ -29,5 +30,14 @@ export const RestEntityTypeCombobox = ({ value, onChange, items, ...props }: Res
     items.push(value);
   }
   const typeItems = items.map<EntityComboboxItem>(type => ({ value: type, label: type === '[B' ? 'Array<byte>' : type }));
-  return <Combobox value={value} onChange={onChange} items={typeItems} {...props} comboboxItem={item => <span>{item.label}</span>} />;
+  return (
+    <ComboboxWithBrowser
+      value={value}
+      onChange={onChange}
+      items={typeItems}
+      browsers={['datatype']}
+      {...props}
+      comboboxItem={item => <span>{item.label}</span>}
+    />
+  );
 };

--- a/packages/editor/src/components/parts/signal/SignalCatchPart.tsx
+++ b/packages/editor/src/components/parts/signal/SignalCatchPart.tsx
@@ -42,6 +42,7 @@ const SignalCatchPart = ({ makroSupport }: { makroSupport?: boolean }) => {
           eventCodes={signalCodes}
           eventIcon={IvyIcons.Signal}
           comboboxInputProps={signalField.inputProps}
+          withBrowser={true}
         />
       </PathFieldset>
       {!makroSupport && (

--- a/packages/editor/src/components/widgets/combobox/Combobox.css
+++ b/packages/editor/src/components/widgets/combobox/Combobox.css
@@ -50,3 +50,14 @@
 .combobox-menu-entry .ivy {
   font-size: 1rem;
 }
+
+.combobox-with-browser {
+  display: flex;
+  gap: var(--size-1);
+  align-items: center;
+}
+
+.combobox-with-browser .combobox {
+  flex: auto;
+  width: 100%;
+}

--- a/packages/editor/src/components/widgets/combobox/ComboboxWithBrowser.tsx
+++ b/packages/editor/src/components/widgets/combobox/ComboboxWithBrowser.tsx
@@ -1,0 +1,23 @@
+import './Combobox.css';
+
+import { Browser, BrowserType, useBrowser } from '../../../components/browser';
+import { usePath } from '../../../context';
+import Combobox, { ComboboxItem, ComboboxProps } from './Combobox';
+
+export type ComboboxWithBrowserProps<T extends ComboboxItem> = ComboboxProps<T> & {
+  browsers: BrowserType[];
+};
+
+const ComboboxWithBrowser = <T extends ComboboxItem>({ items, value, onChange, browsers, ...inputProps }: ComboboxWithBrowserProps<T>) => {
+  const browser = useBrowser();
+  const path = usePath();
+
+  return (
+    <div className='combobox-with-browser'>
+      <Combobox items={items} value={value} onChange={onChange} {...inputProps} />
+      <Browser {...browser} types={browsers} accept={onChange} location={path} />
+    </div>
+  );
+};
+
+export default ComboboxWithBrowser;


### PR DESCRIPTION
I have now created a combobox to which a browser can be added. I managed to implement this combobox in:
- Signal Boundary --> Signal Code
- Rest Client --> Request --> Body -->Entity type
- Rest Client --> Response --> Read body as type.

What is still missing in the Signal Boundary is the support of MacroInput. Currently there is an error message when an element is added to the combobox of the Signal Boundary via Attribute Browser. Should I also take a look at this in this PR or does the improvement of the signal input belong to another story?