### PR TITLE
XIVY-12548 Add Datatype Browser

### DIFF
--- a/packages/editor/src/components/browser/Browser.css
+++ b/packages/editor/src/components/browser/Browser.css
@@ -27,7 +27,6 @@
 }
 .dialog-content .tabs-content {
   gap: var(--size-1);
-  margin-block: var(--size-2);
 }
 .dialog-content .table-root {
   overflow: auto;
@@ -48,6 +47,7 @@
 
 .dialog-title {
   margin: 0;
+  margin-bottom: var(--size-2);
   font-weight: 500;
   color: var(--text-color);
   font-size: 17px;

--- a/packages/editor/src/components/browser/CmsBrowser.test.tsx
+++ b/packages/editor/src/components/browser/CmsBrowser.test.tsx
@@ -52,6 +52,7 @@ describe('CmsBrowser', () => {
     await userEvent.click(await screen.findByRole('cell', { name: 'Macro' }));
     await userEvent.click(screen.getByTestId('accept'));
     expect(data).toEqual('');
+    await userEvent.click(await screen.findByText('Helper Text'));
     expect(screen.getByTitle(`No element selected.`)).toBeInTheDocument();
   });
 });

--- a/packages/editor/src/components/browser/CmsBrowser.tsx
+++ b/packages/editor/src/components/browser/CmsBrowser.tsx
@@ -161,7 +161,7 @@ const CmsBrowser = ({ value, onChange, noApiCall, typeFilter }: CmsBrowserProps)
         </tbody>
       </Table>
 
-      <Collapsible label='Helper Text' defaultOpen={showHelper}>
+      <Collapsible label='Helper Text' defaultOpen={showHelper} autoClosable={true}>
         {value.length !== 0 && selectedContentObject ? (
           <pre className='browser-helptext'>
             <b>{value}</b>

--- a/packages/editor/src/components/browser/DataTypeBrowser.test.tsx
+++ b/packages/editor/src/components/browser/DataTypeBrowser.test.tsx
@@ -55,9 +55,8 @@ describe('DataTypeBrowser', () => {
 
   test('renderCombinedDatatype', async () => {
     renderBrowser();
-    await userEvent.click(await screen.findByPlaceholderText('Search'));
+    await userEvent.click(screen.getByPlaceholderText('Search'));
     await userEvent.keyboard('Person');
-    screen.debug();
     await TableUtil.assertRowCount(1);
   });
 
@@ -65,7 +64,7 @@ describe('DataTypeBrowser', () => {
     let data = '';
     renderBrowser({ accept: value => (data = value) });
     await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
-    await userEvent.click(screen.getByTestId('accept'));
+    await userEvent.click(screen.getByRole('button', { name: '' }));
     expect(data).toEqual('ch.ivyteam.documentation.project.AddContactData');
   });
 
@@ -74,7 +73,7 @@ describe('DataTypeBrowser', () => {
     renderBrowser({ accept: value => (data = value) });
     await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
     await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
-    await userEvent.click(screen.getByTestId('accept'));
+    await userEvent.click(screen.getByRole('button', { name: '' }));
     expect(data).toEqual('');
     await userEvent.click(await screen.findByText('Helper Text'));
     expect(screen.getByTitle(`No element selected.`)).toBeInTheDocument();
@@ -85,19 +84,7 @@ describe('DataTypeBrowser', () => {
     renderBrowser({ accept: value => (data = value) });
     await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
     await userEvent.click(await screen.findByText('Use Type as List'));
-    await userEvent.click(screen.getByTestId('accept'));
-    expect(data).toEqual('java.util.List<AddContactData>');
-  });
-
-  test('listGenericWithList', async () => {
-    renderBrowser();
-    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
-    await userEvent.click(await screen.findByText('Use Type as List'));
-    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
-    await userEvent.click(await screen.findByPlaceholderText('Search'));
-    await userEvent.keyboard('List');
-    expect(screen.getByTitle('The "Use Type as List" checkmark is still enabled, causing lists not to be displayed.')).toBeInTheDocument();
-    await userEvent.click(await screen.findByText('Use Type as List'));
-    await TableUtil.assertRowCount(1);
+    await userEvent.click(screen.getByRole('button', { name: '' }));
+    expect(data).toEqual('java.util.List<ch.ivyteam.documentation.project.AddContactData>');
   });
 });

--- a/packages/editor/src/components/browser/DataTypeBrowser.test.tsx
+++ b/packages/editor/src/components/browser/DataTypeBrowser.test.tsx
@@ -1,0 +1,103 @@
+import { TableUtil, render, screen, userEvent } from 'test-utils';
+import { useDataTypeBrowser } from './DataTypeBrowser';
+
+const Browser = (props: { location: string; accept: (value: string) => void }) => {
+  const browser = useDataTypeBrowser();
+  return (
+    <>
+      {browser.content}
+      <button data-testid='accept' onClick={() => props.accept(browser.accept())} />
+    </>
+  );
+};
+
+describe('DataTypeBrowser', () => {
+  function renderBrowser(options?: { location?: string; accept?: (value: string) => void }) {
+    render(<Browser location={options?.location ?? 'something'} accept={options?.accept ?? (() => {})} />, {
+      wrapperProps: {
+        meta: {
+          datatypes: [
+            {
+              simpleName: 'Person',
+              packageName: 'ch.ivyteam.test',
+              fullQualifiedName: 'ch.ivyteam.test.Person'
+            }
+          ],
+          dataClasses: [
+            {
+              name: 'AddContactData',
+              fullQualifiedName: 'ch.ivyteam.documentation.project.AddContactData',
+              packageName: 'ch.ivyteam.documentation.project',
+              path: 'dataclasses/ch/ivyteam/documentation/project/AddContactData.ivyClass'
+            },
+            {
+              name: 'Person',
+              fullQualifiedName: 'ch.ivyteam.test.Person',
+              packageName: 'ch.ivyteam.test',
+              path: 'dataclasses/ch/ivyteam/test/Person.ivyClass'
+            },
+            {
+              name: 'List',
+              packageName: 'java.util',
+              fullQualifiedName: 'java.util.List',
+              path: 'thisisaTest'
+            }
+          ]
+        }
+      }
+    });
+  }
+
+  test('renderOnlyDataClasses', async () => {
+    renderBrowser();
+    await TableUtil.assertRowCount(3);
+  });
+
+  test('renderCombinedDatatype', async () => {
+    renderBrowser();
+    await userEvent.click(await screen.findByPlaceholderText('Search'));
+    await userEvent.keyboard('Person');
+    screen.debug();
+    await TableUtil.assertRowCount(1);
+  });
+
+  test('accept', async () => {
+    let data = '';
+    renderBrowser({ accept: value => (data = value) });
+    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
+    await userEvent.click(screen.getByTestId('accept'));
+    expect(data).toEqual('ch.ivyteam.documentation.project.AddContactData');
+  });
+
+  test('acceptEmpty', async () => {
+    let data = '';
+    renderBrowser({ accept: value => (data = value) });
+    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
+    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
+    await userEvent.click(screen.getByTestId('accept'));
+    expect(data).toEqual('');
+    await userEvent.click(await screen.findByText('Helper Text'));
+    expect(screen.getByTitle(`No element selected.`)).toBeInTheDocument();
+  });
+
+  test('listGeneric', async () => {
+    let data = '';
+    renderBrowser({ accept: value => (data = value) });
+    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
+    await userEvent.click(await screen.findByText('Use Type as List'));
+    await userEvent.click(screen.getByTestId('accept'));
+    expect(data).toEqual('java.util.List<AddContactData>');
+  });
+
+  test('listGenericWithList', async () => {
+    renderBrowser();
+    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
+    await userEvent.click(await screen.findByText('Use Type as List'));
+    await userEvent.click(await screen.findByRole('cell', { name: 'AddContactData' }));
+    await userEvent.click(await screen.findByPlaceholderText('Search'));
+    await userEvent.keyboard('List');
+    expect(screen.getByTitle('The "Use Type as List" checkmark is still enabled, causing lists not to be displayed.')).toBeInTheDocument();
+    await userEvent.click(await screen.findByText('Use Type as List'));
+    await TableUtil.assertRowCount(1);
+  });
+});

--- a/packages/editor/src/components/browser/DataTypeBrowser.tsx
+++ b/packages/editor/src/components/browser/DataTypeBrowser.tsx
@@ -1,13 +1,225 @@
-import { useState } from 'react';
-import { Input } from '../widgets';
+import { useMemo, useState, useEffect } from 'react';
+import { Checkbox, Collapsible, ExpandableCell, MessageText, SelectRow, Table, TableCell } from '../widgets';
 import { UseBrowserImplReturnValue } from './useBrowser';
+import {
+  ColumnDef,
+  ExpandedState,
+  RowSelectionState,
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getFilteredRowModel,
+  useReactTable
+} from '@tanstack/react-table';
+import { useEditorContext, useMeta } from '../../context';
+import { DataClass, JavaType } from '@axonivy/inscription-protocol';
 export const DATATYPE_BROWSER_ID = 'datatype' as const;
 
 export const useDataTypeBrowser = (): UseBrowserImplReturnValue => {
   const [value, setValue] = useState('datatype');
-  return { id: DATATYPE_BROWSER_ID, name: 'Datatype', content: <DataTypeBrowser value={value} onChange={setValue} />, accept: () => value };
+  return {
+    id: DATATYPE_BROWSER_ID,
+    name: 'Datatype',
+    content: <DataTypeBrowser value={value} onChange={setValue} />,
+    accept: () => value
+  };
 };
 
 const DataTypeBrowser = (props: { value: string; onChange: (value: string) => void }) => {
-  return <Input {...props} />;
+  const { context } = useEditorContext();
+
+  const [datatypeList, setDatatypeList] = useState<JavaType[]>([]);
+  const [mainFilter, setMainFilter] = useState<string>('');
+  const allDatatypes: JavaType[] = useMeta('meta/scripting/allTypes', { context, type: mainFilter }, []).data;
+  const dataClasses: DataClass[] = useMeta('meta/scripting/dataClasses', context, []).data;
+
+  const [typeAsList, setTypeAsList] = useState(false);
+  const [listtypeSelected, setListtypeSelected] = useState(false);
+
+  const [selectedDataType, setSelectedDataType] = useState<JavaType | undefined>();
+  const [showHelper, setShowHelper] = useState(false);
+
+  // Shorter useEffect for merging useMeta's (unfortunately i noticed that in the megat "allTypes" there are also types from the meta "dataClasses", so i created a new useEffect which removes these duplicates.)
+  //  useEffect(() => {
+  //    const mappedDataClasses: JavaType[] = dataClasses.map<JavaType>(dataClass => ({ simpleName: dataClass.name, ...dataClass }));
+  //    if (mainFilter.length === 0) {
+  //      setDatatypeList(mappedDataClasses);
+  //    } else {
+  //      setDatatypeList(allDatatypes.concat(mappedDataClasses));
+  //   }
+  //  }, [allDatatypes, dataClasses, mainFilter]);
+
+  //new useEffect, which removes duplicates
+  useEffect(() => {
+    const mappedDataClasses: JavaType[] = dataClasses.map<JavaType>(dataClass => ({
+      simpleName: dataClass.name,
+      ...dataClass
+    }));
+
+    let combinedList: JavaType[] = [];
+
+    if (mainFilter.length === 0) {
+      combinedList = mappedDataClasses;
+    } else {
+      combinedList = allDatatypes.concat(mappedDataClasses);
+    }
+
+    // Remove duplicates based on 'fullQualifiedName'
+    const uniqueList: JavaType[] = combinedList.reduce((accumulator: JavaType[], current: JavaType) => {
+      const existingItem = accumulator.find(item => item.fullQualifiedName === current.fullQualifiedName);
+      if (!existingItem) {
+        accumulator.push(current);
+      }
+      return accumulator;
+    }, []);
+
+    if (typeAsList) {
+      const uniqueListNoListElements: JavaType[] = uniqueList.filter(item => item.simpleName !== 'List');
+      setDatatypeList(uniqueListNoListElements);
+    } else {
+      setDatatypeList(uniqueList);
+    }
+  }, [allDatatypes, dataClasses, mainFilter, typeAsList]);
+
+  useEffect(() => {
+    setSelectedDataType(undefined);
+    setRowSelection({});
+  }, [mainFilter]);
+
+  const columns = useMemo<ColumnDef<JavaType>[]>(
+    () => [
+      {
+        accessorFn: row => row.simpleName,
+        id: 'simpleName',
+        cell: cell => {
+          return <ExpandableCell cell={cell} title={cell.row.original.simpleName} />;
+        }
+      },
+      {
+        accessorFn: row => row.packageName,
+        id: 'packageName',
+        cell: cell => <span title={cell.row.original.packageName}>{cell.getValue() as string}</span>
+      },
+      {
+        accessorFn: row => row.fullQualifiedName,
+        id: 'fullQualifiedName',
+        cell: cell => <span title={cell.row.original.fullQualifiedName}>{cell.getValue() as string}</span>
+      }
+    ],
+    []
+  );
+
+  const [expanded, setExpanded] = useState<ExpandedState>(true);
+  const [globalFilter, setGlobalFilter] = useState(mainFilter);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  const table = useReactTable({
+    data: datatypeList,
+    columns: columns,
+    state: {
+      expanded,
+      globalFilter,
+      rowSelection
+    },
+    filterFromLeafRows: true,
+    enableRowSelection: true,
+    enableMultiRowSelection: false,
+    enableSubRowSelection: false,
+    onExpandedChange: setExpanded,
+    onGlobalFilterChange: setGlobalFilter,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getFilteredRowModel: getFilteredRowModel()
+  });
+
+  const addListGeneric = (value: JavaType, typeAsList: boolean) => {
+    if (typeAsList) {
+      return 'java.util.List<' + value.simpleName + '>';
+    } else {
+      return value.fullQualifiedName;
+    }
+  };
+
+  useEffect(() => {
+    if (Object.keys(rowSelection).length !== 1) {
+      setSelectedDataType({ fullQualifiedName: '', packageName: '', simpleName: '' });
+      props.onChange('');
+      setShowHelper(false);
+      return;
+    }
+    const selectedRow = table.getRowModel().rowsById[Object.keys(rowSelection)[0]];
+    setSelectedDataType(selectedRow.original);
+    setShowHelper(true);
+    if (selectedRow.original.simpleName === 'List') {
+      setListtypeSelected(true);
+    } else {
+      setListtypeSelected(false);
+    }
+    props.onChange(addListGeneric(selectedRow.original, typeAsList));
+  }, [props, props.onChange, rowSelection, table, typeAsList]);
+
+  return (
+    <>
+      <Table
+        search={{
+          value: globalFilter,
+          onChange: newFilterValue => {
+            setGlobalFilter(newFilterValue);
+            setMainFilter(newFilterValue);
+            setExpanded(true);
+          }
+        }}
+      >
+        <tbody>
+          {table.getRowModel().rows.map(row => (
+            <SelectRow key={row.id} row={row}>
+              {row.getVisibleCells().map(cell => (
+                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+              ))}
+            </SelectRow>
+          ))}
+        </tbody>
+      </Table>
+      {!listtypeSelected && (
+        <>
+          {(props.value.length !== 0 && selectedDataType) || mainFilter === 'List' ? (
+            <>
+              {mainFilter === 'List' && typeAsList && (
+                <MessageText
+                  message={{
+                    severity: 'WARNING',
+                    message: `The "Use Type as List" checkmark is still enabled, causing lists not to be displayed.`
+                  }}
+                />
+              )}
+              <Checkbox label='Use Type as List' value={typeAsList} onChange={() => setTypeAsList(!typeAsList)} />
+            </>
+          ) : null}
+        </>
+      )}
+
+      <Collapsible label='Helper Text' defaultOpen={showHelper} autoClosable={true}>
+        {props.value.length !== 0 && selectedDataType ? (
+          <pre className='browser-helptext'>
+            <b>{props.value}</b>
+            <code>
+              <div>
+                {selectedDataType.simpleName} - {selectedDataType.packageName}
+              </div>
+            </code>
+          </pre>
+        ) : (
+          <pre className='browser-helptext'>
+            <MessageText
+              message={{
+                severity: 'INFO',
+                message: `No element selected.`
+              }}
+            />
+          </pre>
+        )}
+      </Collapsible>
+    </>
+  );
 };

--- a/packages/editor/src/components/widgets/collapsible/Collapsible.tsx
+++ b/packages/editor/src/components/widgets/collapsible/Collapsible.tsx
@@ -5,15 +5,21 @@ import { IvyIcons } from '@axonivy/editor-icons';
 import IvyIcon from '../IvyIcon';
 import { MessageText, MessageTextProps } from '../message/Message';
 
-export type CollapsibleProps = MessageTextProps & { label: string; defaultOpen?: boolean; children: ReactNode };
+export type CollapsibleProps = MessageTextProps & { label: string; defaultOpen?: boolean; autoClosable?: boolean; children: ReactNode };
 
-const Collapsible = ({ label, defaultOpen, message, children }: CollapsibleProps) => {
+const Collapsible = ({ label, defaultOpen, message, children, autoClosable }: CollapsibleProps) => {
   const [open, setOpen] = useState(defaultOpen ?? false);
   useEffect(() => {
-    if (defaultOpen) {
-      setOpen(defaultOpen);
+    if (autoClosable) {
+      if (defaultOpen !== undefined) {
+        setOpen(defaultOpen);
+      }
+    } else {
+      if (defaultOpen) {
+        setOpen(defaultOpen);
+      }
     }
-  }, [defaultOpen]);
+  }, [autoClosable, defaultOpen]);
   return (
     <CollapsibleRoot className='collapsible-root' open={open} onOpenChange={setOpen}>
       <div className='collapsible-header'>

--- a/packages/editor/src/components/widgets/collapsible/Collapsible.tsx
+++ b/packages/editor/src/components/widgets/collapsible/Collapsible.tsx
@@ -11,9 +11,7 @@ const Collapsible = ({ label, defaultOpen, message, children, autoClosable }: Co
   const [open, setOpen] = useState(defaultOpen ?? false);
   useEffect(() => {
     if (autoClosable) {
-      if (defaultOpen !== undefined) {
-        setOpen(defaultOpen);
-      }
+      setOpen(!!defaultOpen);
     } else {
       if (defaultOpen) {
         setOpen(defaultOpen);

--- a/packages/editor/src/components/widgets/input/InputWithBrowser.tsx
+++ b/packages/editor/src/components/widgets/input/InputWithBrowser.tsx
@@ -1,7 +1,7 @@
 import './Input.css';
 import { Browser, BrowserType, useBrowser } from '../../../components/browser';
 import { usePath } from '../../../context';
-import { ComponentProps, forwardRef } from 'react';
+import { ComponentProps } from 'react';
 import Input from './Input';
 import { CmsTypeFilter } from '../../../components/browser/CmsBrowser';
 
@@ -12,18 +12,16 @@ type InputWithBrowserProps = Omit<ComponentProps<'input'>, 'value' | 'onChange' 
   typeFilter: CmsTypeFilter;
 };
 
-const InputWithBrowser = forwardRef<HTMLInputElement, InputWithBrowserProps>(
-  ({ value, onChange, disabled, browsers, typeFilter, ...props }) => {
-    const browser = useBrowser();
-    const path = usePath();
+const InputWithBrowser = ({ value, onChange, disabled, browsers, typeFilter, ...props }: InputWithBrowserProps) => {
+  const browser = useBrowser();
+  const path = usePath();
 
-    return (
-      <div className='input-with-browser'>
-        <Input value={value as string} onChange={onChange} disabled={disabled} {...props} />
-        <Browser {...browser} types={browsers} cmsOptions={{ noApiCall: true, typeFilter: typeFilter }} accept={onChange} location={path} />
-      </div>
-    );
-  }
-);
+  return (
+    <div className='input-with-browser'>
+      <Input value={value as string} onChange={onChange} disabled={disabled} {...props} />
+      <Browser {...browser} types={browsers} cmsOptions={{ noApiCall: true, typeFilter: typeFilter }} accept={onChange} location={path} />
+    </div>
+  );
+};
 
 export default InputWithBrowser;

--- a/packages/editor/src/test-utils/test-utils.tsx
+++ b/packages/editor/src/test-utils/test-utils.tsx
@@ -20,7 +20,9 @@ import {
   RestClientRequest,
   Widget,
   ProgramInterface,
-  ContentObject
+  ContentObject,
+  JavaType,
+  DataClass
 } from '@axonivy/inscription-protocol';
 import { queries, Queries, render, renderHook, RenderHookOptions, RenderOptions } from '@testing-library/react';
 import { deepmerge } from 'deepmerge-ts';
@@ -70,6 +72,8 @@ type ContextHelperProps = {
     javaClasses?: ProgramInterface[];
     widgets?: Widget[];
     contentObject?: ContentObject[];
+    datatypes?: JavaType[];
+    dataClasses?: DataClass[];
   };
   editor?: { title?: string; readonly?: boolean };
 };
@@ -164,6 +168,10 @@ const ContextHelper = (
             return Promise.resolve(props.meta?.widgets ?? []);
           case 'meta/cms/tree':
             return Promise.resolve(props.meta?.contentObject ?? []);
+          case 'meta/scripting/allTypes':
+            return Promise.resolve(props.meta?.javaClasses ?? []);
+          case 'meta/scripting/dataClasses':
+            return Promise.resolve(props.meta?.dataClasses ?? []);
           default:
             throw Error('mock meta path not programmed');
         }

--- a/packages/protocol/src/data/inscription.ts
+++ b/packages/protocol/src/data/inscription.ts
@@ -7,21 +7,21 @@
  */
 
 export type PID = string
-export type ContentObjectType = 'STRING' | 'FILE' | 'FOLDER';
-export type CustomFieldConfigType = 'START' | 'TASK' | 'CASE';
-export type WfFieldType = 'STRING' | 'TEXT' | 'NUMBER' | 'TIMESTAMP';
-export type WfLevel = 'EXCEPTION' | 'HIGH' | 'NORMAL' | 'LOW' | 'SCRIPT';
-export type WfActivatorType = 'ROLE' | 'ROLE_FROM_ATTRIBUTE' | 'USER_FROM_ATTRIBUTE' | 'DELETE_TASK';
-export type CacheInvalidation = 'NONE' | 'FIXED_TIME' | 'LIFETIME';
-export type CacheMode = 'DO_NOT_CACHE' | 'CACHE' | 'INVALIDATE_CACHE';
-export type CacheScope = 'SESSION' | 'APPLICATION';
-export type QueryKind = 'READ' | 'WRITE' | 'UPDATE' | 'DELETE' | 'ANY';
-export type IntermediateEventTimeoutAction = 'NOTHING' | 'DESTROY_TASK' | 'CONTINUE_WITHOUT_EVENT';
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'JAX_RS';
-export type InputType = 'ENTITY' | 'FORM' | 'RAW';
-export type WsAuth = 'NONE' | 'WS_SECURITY' | 'HTTP_BASIC';
-export type Severity = 'INFO' | 'WARNING' | 'ERROR';
-export type Type = 'START' | 'INTERMEDIATE' | 'ACTIVITY';
+export type ContentObjectType = "STRING" | "FILE" | "FOLDER";
+export type CustomFieldConfigType = "START" | "TASK" | "CASE";
+export type WfFieldType = "STRING" | "TEXT" | "NUMBER" | "TIMESTAMP";
+export type WfLevel = "EXCEPTION" | "HIGH" | "NORMAL" | "LOW" | "SCRIPT";
+export type WfActivatorType = "ROLE" | "ROLE_FROM_ATTRIBUTE" | "USER_FROM_ATTRIBUTE" | "DELETE_TASK";
+export type CacheInvalidation = "NONE" | "FIXED_TIME" | "LIFETIME";
+export type CacheMode = "DO_NOT_CACHE" | "CACHE" | "INVALIDATE_CACHE";
+export type CacheScope = "SESSION" | "APPLICATION";
+export type QueryKind = "READ" | "WRITE" | "UPDATE" | "DELETE" | "ANY";
+export type IntermediateEventTimeoutAction = "NOTHING" | "DESTROY_TASK" | "CONTINUE_WITHOUT_EVENT";
+export type HttpMethod = "GET" | "POST" | "PUT" | "HEAD" | "DELETE" | "PATCH" | "OPTIONS" | "JAX_RS";
+export type InputType = "ENTITY" | "FORM" | "RAW";
+export type WsAuth = "NONE" | "WS_SECURITY" | "HTTP_BASIC";
+export type Severity = "INFO" | "WARNING" | "ERROR";
+export type Type = "START" | "INTERMEDIATE" | "ACTIVITY";
 export type Widget = Script | Label | Text;
 
 export interface Inscription {
@@ -113,60 +113,60 @@ export interface InscriptionType {
   description: string;
   iconId: string;
   id:
-    | 'Alternative'
-    | 'CallSubEnd'
-    | 'CallSubStart'
-    | 'CallableSubProcess'
-    | 'Database'
-    | 'DialogCall'
-    | 'EMail'
-    | 'EmbeddedEnd'
-    | 'EmbeddedProcessElement'
-    | 'EmbeddedStart'
-    | 'ErrorBoundaryEvent'
-    | 'ErrorEnd'
-    | 'ErrorStartEvent'
-    | 'GenericActivity'
-    | 'GenericBpmnElement'
-    | 'HtmlDialogEnd'
-    | 'HtmlDialogEventStart'
-    | 'HtmlDialogExit'
-    | 'HtmlDialogMethodStart'
-    | 'HtmlDialogProcess'
-    | 'HtmlDialogStart'
-    | 'Join'
-    | 'ManualBpmnElement'
-    | 'Process'
-    | 'ProcessAnnotation'
-    | 'ProgramInterface'
-    | 'ProgramStart'
-    | 'ReceiveBpmnElement'
-    | 'RequestStart'
-    | 'RestClientCall'
-    | 'RuleBpmnElement'
-    | 'Script'
-    | 'ScriptBpmnElement'
-    | 'SendBpmnElement'
-    | 'ServiceBpmnElement'
-    | 'SignalBoundaryEvent'
-    | 'SignalStartEvent'
-    | 'Split'
-    | 'SubProcessCall'
-    | 'TaskEnd'
-    | 'TaskEndPage'
-    | 'TaskSwitchEvent'
-    | 'TaskSwitchGateway'
-    | 'ThirdPartyProgramInterface'
-    | 'ThirdPartyProgramStart'
-    | 'ThirdPartyWaitEvent'
-    | 'TriggerCall'
-    | 'UserBpmnElement'
-    | 'UserTask'
-    | 'WaitEvent'
-    | 'WebServiceCall'
-    | 'WebserviceEnd'
-    | 'WebserviceProcess'
-    | 'WebserviceStart';
+    | "Alternative"
+    | "CallSubEnd"
+    | "CallSubStart"
+    | "CallableSubProcess"
+    | "Database"
+    | "DialogCall"
+    | "EMail"
+    | "EmbeddedEnd"
+    | "EmbeddedProcessElement"
+    | "EmbeddedStart"
+    | "ErrorBoundaryEvent"
+    | "ErrorEnd"
+    | "ErrorStartEvent"
+    | "GenericActivity"
+    | "GenericBpmnElement"
+    | "HtmlDialogEnd"
+    | "HtmlDialogEventStart"
+    | "HtmlDialogExit"
+    | "HtmlDialogMethodStart"
+    | "HtmlDialogProcess"
+    | "HtmlDialogStart"
+    | "Join"
+    | "ManualBpmnElement"
+    | "Process"
+    | "ProcessAnnotation"
+    | "ProgramInterface"
+    | "ProgramStart"
+    | "ReceiveBpmnElement"
+    | "RequestStart"
+    | "RestClientCall"
+    | "RuleBpmnElement"
+    | "Script"
+    | "ScriptBpmnElement"
+    | "SendBpmnElement"
+    | "ServiceBpmnElement"
+    | "SignalBoundaryEvent"
+    | "SignalStartEvent"
+    | "Split"
+    | "SubProcessCall"
+    | "TaskEnd"
+    | "TaskEndPage"
+    | "TaskSwitchEvent"
+    | "TaskSwitchGateway"
+    | "ThirdPartyProgramInterface"
+    | "ThirdPartyProgramStart"
+    | "ThirdPartyWaitEvent"
+    | "TriggerCall"
+    | "UserBpmnElement"
+    | "UserTask"
+    | "WaitEvent"
+    | "WebServiceCall"
+    | "WebserviceEnd"
+    | "WebserviceProcess"
+    | "WebserviceStart";
   impl?: string;
   label: string;
   shortLabel: string;
@@ -217,17 +217,17 @@ export interface EventCodeMeta {
 }
 export interface InscriptionActionArgs {
   actionId:
-    | 'newHtmlDialog'
-    | 'newProcess'
-    | 'newProgram'
-    | 'newRestClient'
-    | 'newWebServiceClient'
-    | 'openConfig'
-    | 'openCustomField'
-    | 'openEndPage'
-    | 'openPage'
-    | 'openProgram'
-    | 'openTestWs';
+    | "newHtmlDialog"
+    | "newProcess"
+    | "newProgram"
+    | "newRestClient"
+    | "newWebServiceClient"
+    | "openConfig"
+    | "openCustomField"
+    | "openEndPage"
+    | "openPage"
+    | "openProgram"
+    | "openTestWs";
   context: InscriptionContext;
   payload: string | OpenCustomField;
 }
@@ -730,26 +730,26 @@ export interface RoleMeta {
   label: string;
 }
 export interface SchemaKey {
-  Common: 'output' | 'exceptionHandler' | 'code' | 'map';
-  Alternative: 'conditions';
-  Cachable: 'cache';
-  Callable: 'signature' | 'input' | 'result' | 'guid' | 'params';
-  Caller: 'dialog' | 'processCall' | 'call';
-  Database: 'query';
-  Error: 'errorCode' | 'throws';
-  Mail: 'headers' | 'message' | 'attachments' | 'failIfMissingAttachments';
-  Process: 'data' | 'permissions';
-  Programmed: 'javaClass' | 'userConfig' | 'link' | 'timeout' | 'eventId';
+  Common: "output" | "exceptionHandler" | "code" | "map";
+  Alternative: "conditions";
+  Cachable: "cache";
+  Callable: "signature" | "input" | "result" | "guid" | "params";
+  Caller: "dialog" | "processCall" | "call";
+  Database: "query";
+  Error: "errorCode" | "throws";
+  Mail: "headers" | "message" | "attachments" | "failIfMissingAttachments";
+  Process: "data" | "permissions";
+  Programmed: "javaClass" | "userConfig" | "link" | "timeout" | "eventId";
   RestClient: {
-    Common: 'method' | 'target' | 'body' | 'response';
-    Body: 'form' | 'entity' | 'raw';
+    Common: "method" | "target" | "body" | "response";
+    Body: "form" | "entity" | "raw";
   };
-  Script: 'sudo';
-  Signal: 'signalCode' | 'attachToBusinessCase';
-  Start: 'request' | 'permission' | 'triggerable' | 'persistOnStart';
-  WebService: 'clientId' | 'operation' | 'properties';
-  Workflow: 'task' | 'tasks' | 'case' | 'page' | 'customFields';
-  WsProcess: 'wsAuth' | 'wsTypeName' | 'exception';
+  Script: "sudo";
+  Signal: "signalCode" | "attachToBusinessCase";
+  Start: "request" | "permission" | "triggerable" | "persistOnStart";
+  WebService: "clientId" | "operation" | "properties";
+  Workflow: "task" | "tasks" | "case" | "page" | "customFields";
+  WsProcess: "wsAuth" | "wsTypeName" | "exception";
 }
 export interface ScriptingDataArgs {
   context: InscriptionContext;

--- a/packages/protocol/src/data/inscription.ts
+++ b/packages/protocol/src/data/inscription.ts
@@ -7,21 +7,21 @@
  */
 
 export type PID = string
-export type ContentObjectType = "STRING" | "FILE" | "FOLDER";
-export type CustomFieldConfigType = "START" | "TASK" | "CASE";
-export type WfFieldType = "STRING" | "TEXT" | "NUMBER" | "TIMESTAMP";
-export type WfLevel = "EXCEPTION" | "HIGH" | "NORMAL" | "LOW" | "SCRIPT";
-export type WfActivatorType = "ROLE" | "ROLE_FROM_ATTRIBUTE" | "USER_FROM_ATTRIBUTE" | "DELETE_TASK";
-export type CacheInvalidation = "NONE" | "FIXED_TIME" | "LIFETIME";
-export type CacheMode = "DO_NOT_CACHE" | "CACHE" | "INVALIDATE_CACHE";
-export type CacheScope = "SESSION" | "APPLICATION";
-export type QueryKind = "READ" | "WRITE" | "UPDATE" | "DELETE" | "ANY";
-export type IntermediateEventTimeoutAction = "NOTHING" | "DESTROY_TASK" | "CONTINUE_WITHOUT_EVENT";
-export type HttpMethod = "GET" | "POST" | "PUT" | "HEAD" | "DELETE" | "PATCH" | "OPTIONS" | "JAX_RS";
-export type InputType = "ENTITY" | "FORM" | "RAW";
-export type WsAuth = "NONE" | "WS_SECURITY" | "HTTP_BASIC";
-export type Severity = "INFO" | "WARNING" | "ERROR";
-export type Type = "START" | "INTERMEDIATE" | "ACTIVITY";
+export type ContentObjectType = 'STRING' | 'FILE' | 'FOLDER';
+export type CustomFieldConfigType = 'START' | 'TASK' | 'CASE';
+export type WfFieldType = 'STRING' | 'TEXT' | 'NUMBER' | 'TIMESTAMP';
+export type WfLevel = 'EXCEPTION' | 'HIGH' | 'NORMAL' | 'LOW' | 'SCRIPT';
+export type WfActivatorType = 'ROLE' | 'ROLE_FROM_ATTRIBUTE' | 'USER_FROM_ATTRIBUTE' | 'DELETE_TASK';
+export type CacheInvalidation = 'NONE' | 'FIXED_TIME' | 'LIFETIME';
+export type CacheMode = 'DO_NOT_CACHE' | 'CACHE' | 'INVALIDATE_CACHE';
+export type CacheScope = 'SESSION' | 'APPLICATION';
+export type QueryKind = 'READ' | 'WRITE' | 'UPDATE' | 'DELETE' | 'ANY';
+export type IntermediateEventTimeoutAction = 'NOTHING' | 'DESTROY_TASK' | 'CONTINUE_WITHOUT_EVENT';
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'JAX_RS';
+export type InputType = 'ENTITY' | 'FORM' | 'RAW';
+export type WsAuth = 'NONE' | 'WS_SECURITY' | 'HTTP_BASIC';
+export type Severity = 'INFO' | 'WARNING' | 'ERROR';
+export type Type = 'START' | 'INTERMEDIATE' | 'ACTIVITY';
 export type Widget = Script | Label | Text;
 
 export interface Inscription {
@@ -42,6 +42,7 @@ export interface Inscription {
   inscriptionRequest: InscriptionRequest;
   inscriptionSaveRequest: InscriptionSaveRequest;
   inscriptionValidation: InscriptionValidation[];
+  javaType: JavaType[];
   programEditorRequest: ProgramEditorRequest;
   programInterface: ProgramInterface[];
   programInterfacesRequest: ProgramInterfacesRequest;
@@ -55,6 +56,7 @@ export interface Inscription {
   schemaKey: SchemaKey;
   scriptingDataArgs: ScriptingDataArgs;
   string: string;
+  typeSearchRequest: TypeSearchRequest;
   variableInfo: VariableInfo;
   void: Void;
   webServiceClient: WebServiceClient[];
@@ -111,60 +113,60 @@ export interface InscriptionType {
   description: string;
   iconId: string;
   id:
-    | "Alternative"
-    | "CallSubEnd"
-    | "CallSubStart"
-    | "CallableSubProcess"
-    | "Database"
-    | "DialogCall"
-    | "EMail"
-    | "EmbeddedEnd"
-    | "EmbeddedProcessElement"
-    | "EmbeddedStart"
-    | "ErrorBoundaryEvent"
-    | "ErrorEnd"
-    | "ErrorStartEvent"
-    | "GenericActivity"
-    | "GenericBpmnElement"
-    | "HtmlDialogEnd"
-    | "HtmlDialogEventStart"
-    | "HtmlDialogExit"
-    | "HtmlDialogMethodStart"
-    | "HtmlDialogProcess"
-    | "HtmlDialogStart"
-    | "Join"
-    | "ManualBpmnElement"
-    | "Process"
-    | "ProcessAnnotation"
-    | "ProgramInterface"
-    | "ProgramStart"
-    | "ReceiveBpmnElement"
-    | "RequestStart"
-    | "RestClientCall"
-    | "RuleBpmnElement"
-    | "Script"
-    | "ScriptBpmnElement"
-    | "SendBpmnElement"
-    | "ServiceBpmnElement"
-    | "SignalBoundaryEvent"
-    | "SignalStartEvent"
-    | "Split"
-    | "SubProcessCall"
-    | "TaskEnd"
-    | "TaskEndPage"
-    | "TaskSwitchEvent"
-    | "TaskSwitchGateway"
-    | "ThirdPartyProgramInterface"
-    | "ThirdPartyProgramStart"
-    | "ThirdPartyWaitEvent"
-    | "TriggerCall"
-    | "UserBpmnElement"
-    | "UserTask"
-    | "WaitEvent"
-    | "WebServiceCall"
-    | "WebserviceEnd"
-    | "WebserviceProcess"
-    | "WebserviceStart";
+    | 'Alternative'
+    | 'CallSubEnd'
+    | 'CallSubStart'
+    | 'CallableSubProcess'
+    | 'Database'
+    | 'DialogCall'
+    | 'EMail'
+    | 'EmbeddedEnd'
+    | 'EmbeddedProcessElement'
+    | 'EmbeddedStart'
+    | 'ErrorBoundaryEvent'
+    | 'ErrorEnd'
+    | 'ErrorStartEvent'
+    | 'GenericActivity'
+    | 'GenericBpmnElement'
+    | 'HtmlDialogEnd'
+    | 'HtmlDialogEventStart'
+    | 'HtmlDialogExit'
+    | 'HtmlDialogMethodStart'
+    | 'HtmlDialogProcess'
+    | 'HtmlDialogStart'
+    | 'Join'
+    | 'ManualBpmnElement'
+    | 'Process'
+    | 'ProcessAnnotation'
+    | 'ProgramInterface'
+    | 'ProgramStart'
+    | 'ReceiveBpmnElement'
+    | 'RequestStart'
+    | 'RestClientCall'
+    | 'RuleBpmnElement'
+    | 'Script'
+    | 'ScriptBpmnElement'
+    | 'SendBpmnElement'
+    | 'ServiceBpmnElement'
+    | 'SignalBoundaryEvent'
+    | 'SignalStartEvent'
+    | 'Split'
+    | 'SubProcessCall'
+    | 'TaskEnd'
+    | 'TaskEndPage'
+    | 'TaskSwitchEvent'
+    | 'TaskSwitchGateway'
+    | 'ThirdPartyProgramInterface'
+    | 'ThirdPartyProgramStart'
+    | 'ThirdPartyWaitEvent'
+    | 'TriggerCall'
+    | 'UserBpmnElement'
+    | 'UserTask'
+    | 'WaitEvent'
+    | 'WebServiceCall'
+    | 'WebserviceEnd'
+    | 'WebserviceProcess'
+    | 'WebserviceStart';
   impl?: string;
   label: string;
   shortLabel: string;
@@ -215,17 +217,17 @@ export interface EventCodeMeta {
 }
 export interface InscriptionActionArgs {
   actionId:
-    | "newHtmlDialog"
-    | "newProcess"
-    | "newProgram"
-    | "newRestClient"
-    | "newWebServiceClient"
-    | "openConfig"
-    | "openCustomField"
-    | "openEndPage"
-    | "openPage"
-    | "openProgram"
-    | "openTestWs";
+    | 'newHtmlDialog'
+    | 'newProcess'
+    | 'newProgram'
+    | 'newRestClient'
+    | 'newWebServiceClient'
+    | 'openConfig'
+    | 'openCustomField'
+    | 'openEndPage'
+    | 'openPage'
+    | 'openProgram'
+    | 'openTestWs';
   context: InscriptionContext;
   payload: string | OpenCustomField;
 }
@@ -656,6 +658,11 @@ export interface InscriptionValidation {
   path: string;
   severity: Severity;
 }
+export interface JavaType {
+  fullQualifiedName: string;
+  packageName: string;
+  simpleName: string;
+}
 export interface ProgramEditorRequest {
   context: InscriptionContext;
   type: string;
@@ -723,30 +730,34 @@ export interface RoleMeta {
   label: string;
 }
 export interface SchemaKey {
-  Common: "output" | "exceptionHandler" | "code" | "map";
-  Alternative: "conditions";
-  Cachable: "cache";
-  Callable: "signature" | "input" | "result" | "guid" | "params";
-  Caller: "dialog" | "processCall" | "call";
-  Database: "query";
-  Error: "errorCode" | "throws";
-  Mail: "headers" | "message" | "attachments" | "failIfMissingAttachments";
-  Process: "data" | "permissions";
-  Programmed: "javaClass" | "userConfig" | "link" | "timeout" | "eventId";
+  Common: 'output' | 'exceptionHandler' | 'code' | 'map';
+  Alternative: 'conditions';
+  Cachable: 'cache';
+  Callable: 'signature' | 'input' | 'result' | 'guid' | 'params';
+  Caller: 'dialog' | 'processCall' | 'call';
+  Database: 'query';
+  Error: 'errorCode' | 'throws';
+  Mail: 'headers' | 'message' | 'attachments' | 'failIfMissingAttachments';
+  Process: 'data' | 'permissions';
+  Programmed: 'javaClass' | 'userConfig' | 'link' | 'timeout' | 'eventId';
   RestClient: {
-    Common: "method" | "target" | "body" | "response";
-    Body: "form" | "entity" | "raw";
+    Common: 'method' | 'target' | 'body' | 'response';
+    Body: 'form' | 'entity' | 'raw';
   };
-  Script: "sudo";
-  Signal: "signalCode" | "attachToBusinessCase";
-  Start: "request" | "permission" | "triggerable" | "persistOnStart";
-  WebService: "clientId" | "operation" | "properties";
-  Workflow: "task" | "tasks" | "case" | "page" | "customFields";
-  WsProcess: "wsAuth" | "wsTypeName" | "exception";
+  Script: 'sudo';
+  Signal: 'signalCode' | 'attachToBusinessCase';
+  Start: 'request' | 'permission' | 'triggerable' | 'persistOnStart';
+  WebService: 'clientId' | 'operation' | 'properties';
+  Workflow: 'task' | 'tasks' | 'case' | 'page' | 'customFields';
+  WsProcess: 'wsAuth' | 'wsTypeName' | 'exception';
 }
 export interface ScriptingDataArgs {
   context: InscriptionContext;
   location: string;
+}
+export interface TypeSearchRequest {
+  context: InscriptionContext;
+  type: string;
 }
 export interface Void {}
 export interface WebServiceClient {

--- a/packages/protocol/src/inscription-protocol.ts
+++ b/packages/protocol/src/inscription-protocol.ts
@@ -29,7 +29,9 @@ import {
   Widget,
   RestEntityInfoRequest,
   CmsMetaRequest,
-  ContentObject
+  ContentObject,
+  TypeSearchRequest,
+  JavaType
 } from './data/inscription';
 import { InscriptionData, InscriptionSaveData } from './data/inscription-data';
 
@@ -66,6 +68,7 @@ export interface InscriptionMetaRequestTypes {
   'meta/scripting/out': [ScriptingDataArgs, VariableInfo];
   'meta/scripting/in': [ScriptingDataArgs, VariableInfo];
   'meta/scripting/dataClasses': [InscriptionContext, DataClass[]];
+  'meta/scripting/allTypes': [TypeSearchRequest, JavaType[]];
 
   'meta/program/types': [ProgramInterfacesRequest, ProgramInterface[]];
   'meta/program/editor': [ProgramEditorRequest, Widget[]];


### PR DESCRIPTION
First version of the datatype browser and unittests.
I commented out one useEffect in the Datatype-Browser (see reason in the comment itself). What do you think? Should this filter be handled in the backend instead?

Also I used margin in the Browser.css at one point because I couldn't (quickly) achieve it with display: flex and gap. I might try that again to improve it.

Additionally I added a little help, if someone has the checkbox "Use Type as List" set and then searches for lists, he gets a corresponding info that he has to uncheck it if he wants to see lists. Maybe unnecessary (I can also remove it) but I wanted to try it out :-).

ToDo (for another PR):
- IT for Mock
- Still missing the fixed metas for the Ivy datatypes
- Due to the lazy search it is not possible to find elements that are not in the dataClasses by single letters (e.g. all elements with name "List" can only be found if "List" is entered in the search. These do not appear if e.g. only "Li" was entered). Is this ok?
- In the old datatype browser is a separator "Workspace-matches" do I need to include something like this?
![image](https://github.com/axonivy/inscription-client/assets/141223521/0f6b57ba-c511-4d20-8a04-e13d8d686c95)