### PR TITLE
XIVY-12548 Add browsertype to accept

### DIFF
--- a/packages/editor/src/components/browser/Browser.tsx
+++ b/packages/editor/src/components/browser/Browser.tsx
@@ -15,7 +15,7 @@ import { CmsOptions, useCmsBrowser } from './CmsBrowser';
 
 type BrowserProps = UseBrowserReturnValue & {
   types: BrowserType[];
-  accept: (value: string) => void;
+  accept: (value: string, type: BrowserType) => void;
   location: string;
   cmsOptions?: CmsOptions;
 };
@@ -35,7 +35,9 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions }: Br
   const allBrowsers = [attrBrowser, cmsBrowser, funcBrowser, dataTypeBrowser, catPathChooserBrowser, tableColBrowser, sqlOpBrowser];
 
   const tabs = allBrowsers.filter(browser => types.includes(browser.id));
-  const acceptBrowser = () => accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? '');
+  const acceptBrowser = () => {
+    accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? '', active);
+  };
 
   return (
     <>

--- a/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
@@ -10,7 +10,7 @@ import { useOnFocus } from '../../../components/browser/useOnFocus';
 const MacroArea = ({ value, onChange, browsers, ...props }: CodeEditorAreaProps) => {
   const { isFocusWithin, focusWithinProps, focusValue } = useOnFocus(value, onChange);
   const browser = useBrowser();
-  const { setEditor, modifyEditor } = useModifyEditor(value => `<%=${value}%>`);
+  const { setEditor, modifyEditor } = useModifyEditor({ modifyAction: value => `<%=${value}%>` });
   const path = usePath();
   const areaRef = useRef<ElementRef<'output'>>(null);
 

--- a/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroInput.tsx
@@ -11,7 +11,7 @@ type MacroInputProps = Omit<CodeEditorInputProps, 'context'>;
 const MacroInput = ({ value, onChange, browsers, ...props }: MacroInputProps) => {
   const { isFocusWithin, focusWithinProps, focusValue } = useOnFocus(value, onChange);
   const browser = useBrowser();
-  const { setEditor, modifyEditor } = useModifyEditor(value => `<%=${value}%>`);
+  const { setEditor, modifyEditor } = useModifyEditor({ modifyAction: value => `<%=${value}%>` });
   const path = usePath();
 
   return (

--- a/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
@@ -6,7 +6,7 @@ import { usePath } from '../../../context';
 
 const ScriptArea = (props: CodeEditorAreaProps) => {
   const browser = useBrowser();
-  const { setEditor, modifyEditor } = useModifyEditor();
+  const { setEditor, modifyEditor } = useModifyEditor({ scriptAreaDatatypeEditor: true });
   const path = usePath();
 
   return (

--- a/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptInput.tsx
@@ -18,7 +18,7 @@ const ScriptInput = ({
 }: CodeEditorInputProps & { type: string }) => {
   const { isFocusWithin, focusWithinProps, focusValue } = useOnFocus(value, onChange);
   const browser = useBrowser();
-  const { setEditor, modifyEditor } = useModifyEditor(modifyAction);
+  const { setEditor, modifyEditor } = useModifyEditor({ modifyAction: modifyAction });
   const path = usePath();
 
   return (

--- a/packages/editor/src/components/widgets/combobox/Combobox.test.tsx
+++ b/packages/editor/src/components/widgets/combobox/Combobox.test.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import Combobox, { ComboboxItem } from './Combobox';
 import { render, screen, userEvent } from 'test-utils';
+import { BrowserType } from '../../../components/browser';
 
 describe('Combobox', () => {
   function renderCombobox(
@@ -9,6 +10,8 @@ describe('Combobox', () => {
       itemFilter?: (item: ComboboxItem, input?: string) => boolean;
       comboboxItem?: (item: ComboboxItem) => ReactNode;
       onChange?: (change: string) => void;
+      macro?: boolean;
+      browserTypes?: BrowserType[];
     } = {}
   ) {
     const items: ComboboxItem[] = [{ value: 'test' }, { value: 'bla' }];

--- a/packages/editor/src/components/widgets/combobox/Combobox.tsx
+++ b/packages/editor/src/components/widgets/combobox/Combobox.tsx
@@ -82,7 +82,7 @@ const Combobox = <T extends ComboboxItem>({
   }, [items, selectItem, value]);
 
   const readonly = useReadonly();
-  const { setEditor, modifyEditor } = useModifyEditor(value => `<%=${value}%>`);
+  const { setEditor, modifyEditor } = useModifyEditor({ modifyAction: value => `<%=${value}%>` });
   const path = usePath();
   const browser = useBrowser();
   const { isFocusWithin, focusValue, focusWithinProps } = useOnFocus(value, onChange);


### PR DESCRIPTION
I could adjust the 'accept' to include the browser type, and based on that, along with a flag to ensure that it only affects the ScriptArea, I was able to achieve the "import functionality." 

Unfortunately, all the tests of the components with a combobox are failing. As you can see, I haven't made any changes to the combobox or anything similar, so I have no idea why this is suddenly failing, especially when it didn't fail in the PR where I added the editor to the combobox. What should I do now? Should I revert the macro functionality of the combobox, or should I mock the whole thing (as you briefly mentioned before)? If the mock approach is appropriate, we should have a quick call again, as I didn't quite understand how that works.