### PR TITLE
Improve Design and Browserfunctionality

### DIFF
--- a/packages/editor/src/App.css
+++ b/packages/editor/src/App.css
@@ -15,6 +15,13 @@
   --N800: #757575;
   --N900: #4a4a4a;
 
+  --A50: #edf1ff;
+  --A75: #cbd6ff;
+  --A200: #95acff;
+  --A300: #6788ff;
+  --A400: #4870ff;
+  --A500: #2c449c;
+
   --error-color: #ee4a52;
   --warning-color: #ffac5e;
   --success-color: #47c46b;
@@ -22,7 +29,8 @@
 
   /* ------borders------*/
   --basic-border: 1px solid var(--N200);
-  --thick-border: 2px solid var(--N200);
+  --activ-border: 1px solid var(--A200);
+  --thick-border: 1px solid var(--N200);
   --dashed-border: 1px dashed var(--N400);
   --border-radius: 5px;
   --seperator-border: var(--basic-border);
@@ -40,6 +48,7 @@
   --size-3: 0.75rem;
   --size-4: 1rem;
   --input-padding: 10px;
+  --tree-gap: calc((20px + var(--size-1)));
 }
 
 .editor-root {
@@ -63,6 +72,9 @@
   --N500: #757575;
   --N800: #a3a3a3;
   --N900: #a3a3a3;
+
+  --A50: var(--A500);
+  --A75: var(--A300);
 
   --basic-border: 1px solid var(--N200);
   --thick-border: 2px solid var(--N200);

--- a/packages/editor/src/components/browser/AttributeBrowser.test.tsx
+++ b/packages/editor/src/components/browser/AttributeBrowser.test.tsx
@@ -64,7 +64,7 @@ const OUT_VAR_INFO: VariableInfo = {
 };
 
 const Browser = (props: { location: string; accept: (value: string) => void }) => {
-  const browser = useAttributeBrowser(props.location);
+  const browser = useAttributeBrowser(() => {}, props.location);
   return (
     <>
       {browser.content}

--- a/packages/editor/src/components/browser/AttributeBrowser.tsx
+++ b/packages/editor/src/components/browser/AttributeBrowser.tsx
@@ -18,17 +18,27 @@ import { calcFullPathId } from '../parts/common/mapping-tree/useMappingTree';
 
 export const ATTRIBUTE_BROWSER_ID = 'attr' as const;
 
-export const useAttributeBrowser = (location: string): UseBrowserImplReturnValue => {
+export const useAttributeBrowser = (onDoubleClick: () => void, location: string): UseBrowserImplReturnValue => {
   const [value, setValue] = useState('');
   return {
     id: ATTRIBUTE_BROWSER_ID,
     name: 'Attribute',
-    content: <AttributeBrowser value={value} onChange={setValue} location={location} />,
+    content: <AttributeBrowser value={value} onChange={setValue} location={location} onDoubleClick={onDoubleClick} />,
     accept: () => value
   };
 };
 
-const AttributeBrowser = ({ value, onChange, location }: { value: string; onChange: (value: string) => void; location: string }) => {
+const AttributeBrowser = ({
+  value,
+  onChange,
+  location,
+  onDoubleClick
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  location: string;
+  onDoubleClick: () => void;
+}) => {
   const [tree, setTree] = useState<MappingTreeData[]>([]);
   const [varInfo, setVarInfo] = useState<VariableInfo>({ variables: [], types: {} });
 
@@ -125,7 +135,7 @@ const AttributeBrowser = ({ value, onChange, location }: { value: string; onChan
         </thead>
         <tbody>
           {table.getRowModel().rows.map(row => (
-            <SelectRow key={row.id} row={row}>
+            <SelectRow key={row.id} row={row} onDoubleClick={onDoubleClick}>
               {row.getVisibleCells().map(cell => (
                 <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
               ))}

--- a/packages/editor/src/components/browser/Browser.css
+++ b/packages/editor/src/components/browser/Browser.css
@@ -4,7 +4,7 @@
 }
 
 .browser-dialog {
-  background-color: var(--N25);
+  background-color: var(--N75);
   color: var(--body);
   box-shadow: var(--editor-shadow);
   position: absolute;
@@ -34,9 +34,15 @@
   gap: var(--size-1);
 }
 .browser-content .table-root {
+  overflow: hidden;
+}
+.browser-content .table-root .table-container {
+  max-height: calc(100vh - 300px); /* Adjust the height as needed */
   overflow: auto;
-  max-height: calc(100vh - 200px);
-  padding: 1px;
+}
+.browser-content .table-root .table-container .table {
+  overflow: auto;
+  max-height: 100%;
 }
 .browser-content .browser-helptext {
   font-size: 12px;
@@ -44,7 +50,7 @@
   border: var(--basic-border);
   padding: var(--input-padding);
   overflow: auto;
-  max-height: 50vh;
+  max-height: 80px;
   display: flex;
   flex-direction: column;
   gap: var(--size-1);

--- a/packages/editor/src/components/browser/Browser.tsx
+++ b/packages/editor/src/components/browser/Browser.tsx
@@ -24,10 +24,19 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions }: Br
   const { editorRef } = useEditorContext();
   const [active, setActive] = useState<BrowserType>(types[0]);
 
-  const attrBrowser = useAttributeBrowser(location);
-  const cmsBrowser = useCmsBrowser(cmsOptions);
+  const acceptBrowser = () => {
+    accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? '', active);
+  };
+
+  const onRowDoubleClick = () => {
+    onOpenChange(false);
+    acceptBrowser();
+  };
+
+  const attrBrowser = useAttributeBrowser(onRowDoubleClick, location);
+  const cmsBrowser = useCmsBrowser(onRowDoubleClick, cmsOptions);
   const funcBrowser = useFuncBrowser();
-  const dataTypeBrowser = useDataTypeBrowser();
+  const dataTypeBrowser = useDataTypeBrowser(onRowDoubleClick);
   const catPathChooserBrowser = useCatPathChooserBrowser();
   const tableColBrowser = useTableColBrowser();
   const sqlOpBrowser = useSqlOpBrowser();
@@ -35,9 +44,6 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions }: Br
   const allBrowsers = [attrBrowser, cmsBrowser, funcBrowser, dataTypeBrowser, catPathChooserBrowser, tableColBrowser, sqlOpBrowser];
 
   const tabs = allBrowsers.filter(browser => types.includes(browser.id));
-  const acceptBrowser = () => {
-    accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? '', active);
-  };
 
   return (
     <>

--- a/packages/editor/src/components/browser/CmsBrowser.test.tsx
+++ b/packages/editor/src/components/browser/CmsBrowser.test.tsx
@@ -2,7 +2,7 @@ import { TableUtil, render, screen, userEvent } from 'test-utils';
 import { useCmsBrowser } from './CmsBrowser';
 
 const Browser = (props: { location: string; accept: (value: string) => void }) => {
-  const browser = useCmsBrowser();
+  const browser = useCmsBrowser(() => {});
   return (
     <>
       {browser.content}

--- a/packages/editor/src/components/browser/CmsBrowser.tsx
+++ b/packages/editor/src/components/browser/CmsBrowser.tsx
@@ -26,13 +26,21 @@ export type CmsOptions = {
   typeFilter?: CmsTypeFilter;
 };
 
-export const useCmsBrowser = (options?: CmsOptions): UseBrowserImplReturnValue => {
+export const useCmsBrowser = (onDoubleClick: () => void, options?: CmsOptions): UseBrowserImplReturnValue => {
   const [value, setValue] = useState('');
 
   return {
     id: CMS_BROWSER_ID,
     name: 'CMS',
-    content: <CmsBrowser value={value} onChange={setValue} noApiCall={options?.noApiCall} typeFilter={options?.typeFilter} />,
+    content: (
+      <CmsBrowser
+        value={value}
+        onChange={setValue}
+        noApiCall={options?.noApiCall}
+        typeFilter={options?.typeFilter}
+        onDoubleClick={onDoubleClick}
+      />
+    ),
     accept: () => value
   };
 };
@@ -42,9 +50,10 @@ interface CmsBrowserProps {
   onChange: (value: string) => void;
   noApiCall?: boolean;
   typeFilter?: CmsTypeFilter;
+  onDoubleClick: () => void;
 }
 
-const CmsBrowser = ({ value, onChange, noApiCall, typeFilter }: CmsBrowserProps) => {
+const CmsBrowser = ({ value, onChange, noApiCall, typeFilter, onDoubleClick }: CmsBrowserProps) => {
   const { context } = useEditorContext();
 
   const [requiredProject, setRequiredProject] = useState<boolean>(false);
@@ -154,7 +163,7 @@ const CmsBrowser = ({ value, onChange, noApiCall, typeFilter }: CmsBrowserProps)
       >
         <tbody>
           {table.getRowModel().rows.map(row => (
-            <SelectRow key={row.id} row={row} isNotSelectable={row.original.type === 'FOLDER'}>
+            <SelectRow key={row.id} row={row} isNotSelectable={row.original.type === 'FOLDER'} onDoubleClick={onDoubleClick}>
               {row.getVisibleCells().map(cell => (
                 <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
               ))}

--- a/packages/editor/src/components/browser/DataTypeBrowser.test.tsx
+++ b/packages/editor/src/components/browser/DataTypeBrowser.test.tsx
@@ -2,7 +2,7 @@ import { TableUtil, render, screen, userEvent } from 'test-utils';
 import { useDataTypeBrowser } from './DataTypeBrowser';
 
 const Browser = (props: { location: string; accept: (value: string) => void }) => {
-  const browser = useDataTypeBrowser();
+  const browser = useDataTypeBrowser(() => {});
   return (
     <>
       {browser.content}

--- a/packages/editor/src/components/browser/DataTypeBrowser.tsx
+++ b/packages/editor/src/components/browser/DataTypeBrowser.tsx
@@ -16,17 +16,17 @@ import { useEditorContext, useMeta } from '../../context';
 import { JavaType } from '@axonivy/inscription-protocol';
 export const DATATYPE_BROWSER_ID = 'datatype' as const;
 
-export const useDataTypeBrowser = (): UseBrowserImplReturnValue => {
+export const useDataTypeBrowser = (onDoubleClick: () => void): UseBrowserImplReturnValue => {
   const [value, setValue] = useState('datatype');
   return {
     id: DATATYPE_BROWSER_ID,
     name: 'Datatype',
-    content: <DataTypeBrowser value={value} onChange={setValue} />,
+    content: <DataTypeBrowser value={value} onChange={setValue} onDoubleClick={onDoubleClick} />,
     accept: () => value
   };
 };
 
-const DataTypeBrowser = (props: { value: string; onChange: (value: string) => void }) => {
+const DataTypeBrowser = (props: { value: string; onChange: (value: string) => void; onDoubleClick: () => void }) => {
   const { context } = useEditorContext();
 
   const [mainFilter, setMainFilter] = useState('');
@@ -71,10 +71,10 @@ const DataTypeBrowser = (props: { value: string; onChange: (value: string) => vo
   const columns = useMemo<ColumnDef<JavaType>[]>(
     () => [
       {
-        accessorFn: row => `${row.simpleName} - ${row.packageName}`,
+        accessorFn: row => row.simpleName,
         id: 'simpleName',
         cell: cell => {
-          return <ExpandableCell cell={cell} title={cell.row.original.simpleName} />;
+          return <ExpandableCell cell={cell} title={cell.row.original.simpleName} additionalInfo={cell.row.original.packageName} />;
         }
       }
     ],
@@ -195,7 +195,7 @@ const DataTypeBrowser = (props: { value: string; onChange: (value: string) => vo
       >
         <tbody>
           {tableStatic.getRowModel().rows.map(row => (
-            <SelectRow key={row.id} row={row}>
+            <SelectRow key={row.id} row={row} onDoubleClick={props.onDoubleClick}>
               {row.getVisibleCells().map(cell => (
                 <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
               ))}

--- a/packages/editor/src/components/parts/common/mapping-tree/MappingPart.test.tsx
+++ b/packages/editor/src/components/parts/common/mapping-tree/MappingPart.test.tsx
@@ -5,11 +5,11 @@ import MappingPart from './MappingPart';
 describe('MappingPart', () => {
   const ATTRIBUTES = /Attribute/;
   const PARAMS = /param.procurementRequest/;
-  const NODE_PARAMS = /🔵 param.procurementRequest/;
-  const NODE_BOOLEAN = /🔵 acceptedBoolean/;
-  const NODE_NUMBER = /🔵 amountNumber/;
+  const NODE_PARAMS = /param.procurementRequest/;
+  const NODE_BOOLEAN = /acceptedBoolean/;
+  const NODE_NUMBER = /amountNumber/;
   const USER = /requesterUser/;
-  const NODE_STRING = /🔵 emailString/;
+  const NODE_STRING = /emailString/;
 
   const variableInfo: VariableInfo = {
     variables: [
@@ -94,7 +94,7 @@ describe('MappingPart', () => {
 
   test('tree will render unknown values', () => {
     renderTree({ bla: 'unknown value' });
-    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER, /⛔ bla/]);
+    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER, /⛔bla/]);
   });
 
   test('tree will render description title', () => {

--- a/packages/editor/src/components/parts/rest/rest-request/rest-body/RestEntity.test.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-body/RestEntity.test.tsx
@@ -21,7 +21,7 @@ describe('RestEntity', () => {
   test('empty', async () => {
     renderPart();
     await screen.findByText('param');
-    TableUtil.assertRows(['🔵 param String']);
+    TableUtil.assertRows(['param String']);
     expect(screen.getByLabelText('Code')).toHaveValue('');
   });
 

--- a/packages/editor/src/components/widgets/accordion/Accordion.css
+++ b/packages/editor/src/components/widgets/accordion/Accordion.css
@@ -11,7 +11,7 @@
 }
 .accordion-item:has([data-state='open']) .accordion-header,
 .accordion-item:has([data-state='open']) .accordion-trigger {
-  background-color: var(--N25);
+  background-color: var(--N75);
   border-bottom: none;
   font-weight: 600;
 }
@@ -45,11 +45,11 @@
   cursor: pointer;
 }
 .accordion-trigger:focus-visible {
-  box-shadow: var(--focus-shadow);
+  border: var(--activ-border);
 }
 .accordion-content {
   overflow: hidden;
-  background-color: var(--N25);
+  background-color: var(--N75);
 }
 .accordion-content[data-state='open'] {
   animation: accordionSlideDown 200ms cubic-bezier(0.87, 0, 0.13, 1);

--- a/packages/editor/src/components/widgets/checkbox/Checkbox.css
+++ b/packages/editor/src/components/widgets/checkbox/Checkbox.css
@@ -19,17 +19,18 @@ button {
 }
 .checkbox-root:hover {
   cursor: pointer;
-  background-color: var(--N25);
+  background-color: var(--A50);
 }
 .checkbox-root[data-state='checked'] {
-  background-color: var(--N25);
+  background-color: var(--A50);
+  border: var(--activ-border);
 }
 .checkbox-root:focus-visible {
   box-shadow: var(--focus-shadow);
 }
 
 .checkbox-indicator svg path {
-  fill: var(--body);
+  fill: var(--A400);
 }
 
 .checkbox-label {

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.css
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.css
@@ -1,10 +1,14 @@
 .code-editor .code-input {
   border-radius: var(--border-radius);
-  border: var(--basic-border) !important;
+  border: var(--basic-border);
   background: var(--background);
   font-size: 12px;
   line-height: 12px;
   color: var(--body);
   text-align: start;
   padding: var(--input-padding);
+}
+
+.code-editor .code-input:focus-within {
+  border: var(--activ-border);
 }

--- a/packages/editor/src/components/widgets/combobox/Combobox.css
+++ b/packages/editor/src/components/widgets/combobox/Combobox.css
@@ -48,10 +48,11 @@
   border-bottom: none;
 }
 .combobox-menu-entry.hover {
-  background: var(--N50);
+  background: var(--A50);
 }
 .combobox-menu-entry.selected {
-  background: var(--N100);
+  background: var(--A400);
+  color: var(--background);
 }
 .combobox-menu-entry-additional {
   color: var(--seperator-color);

--- a/packages/editor/src/components/widgets/input/Input.css
+++ b/packages/editor/src/components/widgets/input/Input.css
@@ -14,7 +14,7 @@
   cursor: not-allowed !important;
 }
 .input:focus {
-  box-shadow: var(--focus-shadow);
+  border: var(--activ-border);
 }
 textarea.input {
   resize: vertical;

--- a/packages/editor/src/components/widgets/radio/Radio.css
+++ b/packages/editor/src/components/widgets/radio/Radio.css
@@ -17,13 +17,14 @@
   border: var(--basic-border);
 }
 .radio-group-item:hover {
-  background-color: var(--N25);
+  background-color: var(--A50);
 }
 .radio-group-item:focus {
-  box-shadow: var(--N25);
+  box-shadow: var(--A50);
 }
 .radio-group-item[data-state='checked'] {
-  background-color: var(--N25);
+  background-color: var(--A50);
+  border: var(--activ-border);
 }
 .radio-group-indicator {
   display: flex;
@@ -39,7 +40,7 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background-color: var(--body);
+  background-color: var(--A400);
 }
 
 .radio-group-label {

--- a/packages/editor/src/components/widgets/select/Select.css
+++ b/packages/editor/src/components/widgets/select/Select.css
@@ -18,8 +18,11 @@
   gap: var(--size-1);
   width: 100%;
 }
+.select-button:focus {
+  border: var(--activ-border);
+}
 .select-button:focus-visible {
-  box-shadow: var(--focus-shadow);
+  border: var(--activ-border);
 }
 .select-button .ivy-angle-down {
   font-size: 16px;
@@ -48,15 +51,16 @@
   padding: var(--size-2);
   min-height: 1em;
   cursor: pointer;
-  border-bottom: var(--basic-border);
+  border-bottom: var(--seperator-border);
 }
 .select-menu-entry:last-child {
   border-bottom: none; /* Remove the border from the last entry */
 }
 .select-menu-entry.hover {
-  background: var(--N50);
+  background: var(--A50);
 }
 
 .select-menu-entry.selected {
-  background: var(--N100);
+  background: var(--A400);
+  color: var(--background);
 }

--- a/packages/editor/src/components/widgets/table/cell/ExpandableCell.css
+++ b/packages/editor/src/components/widgets/table/cell/ExpandableCell.css
@@ -9,3 +9,12 @@
 .table-cell .row-expand-button[data-state='collapsed'] .ivy-angle-down {
   transform: rotate(-90deg);
 }
+
+.table-cell .row-expand-label {
+  font-weight: bold;
+}
+
+.table-cell .row-expand-label-info {
+  font-style: italic;
+  color: var(--N700);
+}

--- a/packages/editor/src/components/widgets/table/cell/ExpandableCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/ExpandableCell.tsx
@@ -11,9 +11,18 @@ type ExpandableCellProps<TData> = {
   isUnknown?: boolean;
   icon?: IvyIcons;
   title?: string;
+  additionalInfo?: string;
 };
 
-export function ExpandableCell<TData>({ cell, isLoaded, loadChildren, isUnknown, icon, title }: ExpandableCellProps<TData>) {
+export function ExpandableCell<TData>({
+  cell,
+  isLoaded,
+  loadChildren,
+  isUnknown,
+  icon,
+  title,
+  additionalInfo
+}: ExpandableCellProps<TData>) {
   const row = cell.row;
   const onClick = () => {
     if (isLoaded === false && loadChildren) {
@@ -22,7 +31,7 @@ export function ExpandableCell<TData>({ cell, isLoaded, loadChildren, isUnknown,
     row.toggleExpanded(true);
   };
   return (
-    <div className='row-expand' style={{ paddingLeft: `${row.depth}rem` }} title={title}>
+    <div className='row-expand' style={{ paddingLeft: `calc(${row.depth}*(var(--tree-gap))` }} title={title}>
       {row.getCanExpand() ? (
         <>
           <Button
@@ -39,12 +48,10 @@ export function ExpandableCell<TData>({ cell, isLoaded, loadChildren, isUnknown,
       ) : isUnknown === true ? (
         '⛔'
       ) : (
-        <>
-          🔵
-          {icon && <IvyIcon icon={icon} />}
-        </>
-      )}{' '}
-      <span className='row-expand-label'>{cell.getValue() as string}</span>
+        <>{icon && <IvyIcon icon={icon} />}</>
+      )}
+      <span className={additionalInfo ? 'row-expand-label' : ''}>{cell.getValue() as string}</span>
+      {additionalInfo && <span className='row-expand-label-info'>- {additionalInfo}</span>}
     </div>
   );
 }

--- a/packages/editor/src/components/widgets/table/row/SelectRow.css
+++ b/packages/editor/src/components/widgets/table/row/SelectRow.css
@@ -2,9 +2,16 @@
   cursor: pointer;
 }
 .selectable-row:where(:hover) {
-  background-color: var(--N50);
+  background-color: var(--A50);
 }
 
-.selectable-row:where([data-state='selected']) {
-  background-color: var(--N100);
+.selectable-row:where([data-state='selected']),
+.selectable-row:where([data-state='selected']) .table-cell .row-expand .row-expand-label-info {
+  background-color: var(--A400);
+  color: var(--background);
+}
+
+.selectable-row:where([data-state='selected']) .table-cell .row-expand .row-expand-button:hover {
+  background-color: var(--background);
+  color: var(--A400);
 }

--- a/packages/editor/src/components/widgets/table/row/SelectRow.tsx
+++ b/packages/editor/src/components/widgets/table/row/SelectRow.tsx
@@ -6,13 +6,22 @@ type SelectRowProps<TData> = {
   row: Row<TData>;
   children: ReactNode;
   isNotSelectable?: boolean;
+  onDoubleClick?: () => void;
 };
 
-export const SelectRow = <TData extends object>({ row, children, isNotSelectable }: SelectRowProps<TData>) => (
+export const SelectRow = <TData extends object>({ row, children, isNotSelectable, onDoubleClick }: SelectRowProps<TData>) => (
   <tr
     className={isNotSelectable ? '' : 'selectable-row'}
     data-state={row.getIsSelected() ? 'selected' : ''}
-    onClick={isNotSelectable ? undefined : row.getToggleSelectedHandler()}
+    onClick={event => {
+      if (!isNotSelectable) {
+        if (event.detail === 1) {
+          row.getToggleSelectedHandler()(event);
+        } else if (onDoubleClick) {
+          onDoubleClick();
+        }
+      }
+    }}
   >
     {children}
   </tr>

--- a/packages/editor/src/components/widgets/table/table/Table.css
+++ b/packages/editor/src/components/widgets/table/table/Table.css
@@ -6,7 +6,6 @@
   position: sticky;
   top: 0;
   z-index: 1;
-  border-bottom: var(--size-1) solid var(--N25);
 }
 .table {
   width: 100%;
@@ -18,4 +17,16 @@
 
 .table tr :where(td) {
   border-top: var(--seperator-border);
+}
+
+.table tr:last-child td:first-child {
+  border-bottom-left-radius: var(--border-radius);
+}
+
+.table tr:last-child td:last-child {
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.table tr:first-child td {
+  border-top: none;
 }

--- a/packages/editor/src/components/widgets/table/table/Table.tsx
+++ b/packages/editor/src/components/widgets/table/table/Table.tsx
@@ -8,6 +8,8 @@ type TableProps = { search?: { value: string; onChange: (value: string) => void 
 export const Table = ({ search, children }: TableProps) => (
   <div className='table-root'>
     {search && <IconInput icon={IvyIcons.Search} placeholder='Search' {...search} />}
-    <table className='table'>{children}</table>
+    <div className='table-container'>
+      <table className='table'>{children}</table>
+    </div>
   </div>
 );


### PR DESCRIPTION
Added doubleclick-insert to cms- & datatype-browser. Should I also add it to the attribute-browser?
Improved table- and helpertextheight for the browsers
Adjusted the paddingleft for Treetables/removed blue cirle
Made simpleName in Datatype-Browser bold
Color-Changes: 
- Better contrast (as Sprint-Review suggested)
- New Hover and Selectstate-color "blue" for Input/ScriptInput/Combobox/checkbox/radio/table