### PR TITLE
Fix warning in root tsconfig.json

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -17,6 +17,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "ESNext",
+    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "esModuleInterop": true,

--- a/config/tsconfig.package.json
+++ b/config/tsconfig.package.json
@@ -5,7 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "emitDecoratorMetadata": true,
-    "moduleResolution": "node",
     "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
Option '--resolveJsonModule' cannot be specified when 'moduleResolution' is set to 'classic'