### PR TITLE
XIVY-12684 Fix navigate to process in integration

### DIFF
--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.css';
 import '@axonivy/editor-icons/src-gen/ivy-icons.css';
-import type { ElementData, InscriptionData, InscriptionElementContext, InscriptionValidation } from '@axonivy/inscription-protocol';
+import type { ElementData, InscriptionData, InscriptionElementContext, InscriptionValidation, PID } from '@axonivy/inscription-protocol';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { DataContextInstance, DEFAULT_EDITOR_CONTEXT, EditorContextInstance, useClient, useTheme } from './context';
 import { inscriptionEditor } from './components/editors/InscriptionEditor';
@@ -91,7 +91,8 @@ function App(props: InscriptionElementContext) {
           context,
           readonly: data.readonly ?? DEFAULT_EDITOR_CONTEXT.readonly,
           editorRef,
-          type: data.type ?? DEFAULT_EDITOR_CONTEXT.type
+          type: data.type ?? DEFAULT_EDITOR_CONTEXT.type,
+          navigateTo: (pid: PID) => setContext(old => ({ ...old, pid }))
         }}
       >
         <DataContextInstance.Provider

--- a/packages/editor/src/components/editors/InscriptionEditor.css
+++ b/packages/editor/src/components/editors/InscriptionEditor.css
@@ -6,6 +6,10 @@ button:disabled {
   cursor: not-allowed !important;
 }
 
+a {
+  color: var(--A300);
+}
+
 .editor {
   color: var(--body);
   display: flex;

--- a/packages/editor/src/components/parts/web-service/WebServicePart.tsx
+++ b/packages/editor/src/components/parts/web-service/WebServicePart.tsx
@@ -1,5 +1,5 @@
 import type { WebserviceStartData } from '@axonivy/inscription-protocol';
-import type { PartProps} from '../../../components/editors';
+import type { PartProps } from '../../../components/editors';
 import { usePartDirty, usePartState } from '../../../components/editors';
 import { useEditorContext, useValidations } from '../../../context';
 import { useWebServiceData } from './useWebServiceData';
@@ -18,13 +18,9 @@ export function useWebServicePart(): PartProps {
 }
 
 const WebServicePart = () => {
-  const { context } = useEditorContext();
+  const { context, navigateTo } = useEditorContext();
   const { config, defaultConfig, updatePermission } = useWebServiceData();
-  const navigateToProcess = () => {
-    const url = new URL(window.location.href);
-    url.searchParams.set('pid', PID.processId(context.pid));
-    window.location.replace(url);
-  };
+  const navigateToProcess = () => navigateTo(PID.processId(context.pid));
 
   return (
     <>

--- a/packages/editor/src/context/useEditorContext.ts
+++ b/packages/editor/src/context/useEditorContext.ts
@@ -1,4 +1,4 @@
-import type { InscriptionElementContext, InscriptionType } from '@axonivy/inscription-protocol';
+import type { InscriptionElementContext, InscriptionType, PID } from '@axonivy/inscription-protocol';
 import { createContext, useContext } from 'react';
 
 export type EditorContext = {
@@ -6,6 +6,7 @@ export type EditorContext = {
   readonly: boolean;
   editorRef: React.MutableRefObject<HTMLElement | null>;
   type: InscriptionType;
+  navigateTo: (pid: PID) => void;
 };
 
 export const DEFAULT_EDITOR_CONTEXT: EditorContext = {
@@ -18,7 +19,8 @@ export const DEFAULT_EDITOR_CONTEXT: EditorContext = {
     shortLabel: 'Unknown',
     description: 'This is an Inscription Editor for an unknown element type',
     iconId: 'unknown'
-  }
+  },
+  navigateTo: () => {}
 };
 
 export const EditorContextInstance = createContext<EditorContext>(DEFAULT_EDITOR_CONTEXT);


### PR DESCRIPTION
This affects the link on the webservice start which changes the inscription view to the webservice process.

As the old solution changes the url of the window, this solution works in the standalone inscription view, but not integrated into the process editor.