### PR TITLE
Fix popover collisionBoundary aware

### DIFF
--- a/packages/editor/src/components/widgets/popover/Popover.css
+++ b/packages/editor/src/components/widgets/popover/Popover.css
@@ -1,6 +1,6 @@
 .popover-content {
   border-radius: var(--border-radius);
-  width: min(90vw, 400px);
+  width: min(400px, calc(var(--radix-popover-content-available-width) - 2 * var(--size-2)));
   background-color: var(--N25);
   box-shadow: var(--popover-shadow);
   animation-duration: 400ms;

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -69,7 +69,7 @@ export function CodeEditorCell<TData>({ cell, makro, type, browsers }: CodeEdito
             />
           </PopoverTrigger>
           <PopoverPortal container={editorContext.editorRef.current}>
-            <PopoverContent className='popover-content' sideOffset={5} align={'end'}>
+            <PopoverContent className='popover-content' sideOffset={5} align={'end'} collisionBoundary={editorContext.editorRef.current}>
               <Fieldset label='Code' {...codeFieldset.labelProps}>
                 <div className='script-input'>
                   <SingleLineCodeEditor

--- a/packages/editor/src/components/widgets/tag/Tags.tsx
+++ b/packages/editor/src/components/widgets/tag/Tags.tsx
@@ -63,7 +63,7 @@ const Tags = (props: { tags: string[]; onChange: (tags: string[]) => void }) => 
           </button>
         </Popover.Trigger>
         <Popover.Portal container={editorContext.editorRef.current}>
-          <Popover.Content className='popover-content' sideOffset={5}>
+          <Popover.Content className='popover-content' sideOffset={5} collisionBoundary={editorContext.editorRef.current}>
             <Fieldset label='New Tag' {...tagFieldset.labelProps}>
               <Input value={newTag} {...keyboardProps} onChange={change => setNewTag(change)} {...tagFieldset.inputProps} />
             </Fieldset>


### PR DESCRIPTION
Add collisionBoundary to popover content to make it aware of the editor boundary

Before:
![Screenshot 2023-11-24 at 13 34 22](https://github.com/axonivy/inscription-client/assets/42733123/3b77425d-43df-46c8-bbeb-6c2957489ad1)

After:
![Screenshot 2023-11-24 at 13 33 35](https://github.com/axonivy/inscription-client/assets/42733123/2d7a6e89-31ac-4cf2-a526-b79cf97e83ac)