### PR TITLE
Stabilize e2e test

### DIFF
--- a/integrations/standalone/tests/pageobjects/Table.ts
+++ b/integrations/standalone/tests/pageobjects/Table.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page} from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { Popover } from './Popover';
 import { ScriptCell } from './CodeEditor';
@@ -35,9 +35,8 @@ export class Table {
   async clear() {
     let totalRows = await this.rows.count();
     while (totalRows > 0) {
-      for (let row = 0; row < totalRows; row++) {
-        await this.row(row).remove();
-      }
+      await this.row(0).remove();
+      await expect(this.rows).toHaveCount(totalRows - 1);
       totalRows = await this.rows.count();
     }
   }


### PR DESCRIPTION
I think, I finally found one of the lines that causes so many tests to flakines...

The problem here was that the clean method of the table iterates over every row and removes them, by checking the count of the rows.
But the await on the remove call only waits until the "button is clicked", but this doesn't mean that the code behind this button removed it from the table. So probably the next count on the rows happens with the previous row still visible.
With the check that the row count needs to be the current count - 1 it waits until this condition is true or fails if it is not.