### PR TITLE
XIVY-12992 Improve Browsers & adjust Typebrowser

### DIFF
--- a/integrations/standalone/tests/mock/browser.spec.ts
+++ b/integrations/standalone/tests/mock/browser.spec.ts
@@ -150,10 +150,7 @@ test.describe('Script browser', () => {
     await expect(page.getByRole('dialog')).toBeVisible();
 
     await page.getByText(browser).first().click();
-    if (browser === 'Type') {
-      await page.click('.icon-input input');
-      await page.keyboard.insertText('Per');
-    }
+
     await page.getByRole('row').nth(rowToCheck).click();
 
     if (checkListGeneric && browser === 'Type') {
@@ -173,10 +170,7 @@ test.describe('Script browser', () => {
     await expect(page.getByRole('dialog')).toBeVisible();
 
     await page.getByText(browser).first().click();
-    if (browser === 'Type') {
-      await page.click('.icon-input input');
-      await page.keyboard.insertText('Per');
-    }
+
     await page.getByRole('row').nth(rowToCheck).click();
     await page.getByRole('row').nth(rowToCheck).dblclick();
 

--- a/packages/editor/src/components/browser/AttributeBrowser.tsx
+++ b/packages/editor/src/components/browser/AttributeBrowser.tsx
@@ -7,6 +7,7 @@ import { MappingTreeData } from '../parts/common/mapping-tree/mapping-tree-data'
 import type { VariableInfo } from '@axonivy/inscription-protocol';
 import { useEditorContext, useMeta } from '../../context';
 import { calcFullPathId } from '../parts/common/mapping-tree/useMappingTree';
+import { IvyIcons } from '@axonivy/editor-icons';
 
 export const ATTRIBUTE_BROWSER_ID = 'attr' as const;
 
@@ -14,6 +15,7 @@ export const useAttributeBrowser = (onDoubleClick: () => void, location: string)
   const [value, setValue] = useState('');
   return {
     id: ATTRIBUTE_BROWSER_ID,
+    icon: IvyIcons.Attribute,
     name: 'Attribute',
     content: <AttributeBrowser value={value} onChange={setValue} location={location} onDoubleClick={onDoubleClick} />,
     accept: () => value
@@ -68,6 +70,7 @@ const AttributeBrowser = ({
             loadChildren={() => loadChildren(cell.row.original)}
             title={cell.row.original.description}
             additionalInfo={cell.row.original.simpleType}
+            icon={IvyIcons.Attribute}
           />
         )
       }

--- a/packages/editor/src/components/browser/CatPathChooser.tsx
+++ b/packages/editor/src/components/browser/CatPathChooser.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Input } from '../widgets';
 import type { UseBrowserImplReturnValue } from './useBrowser';
+import { IvyIcons } from '@axonivy/editor-icons';
 export const CAT_PATH_CHOOSER_BROWSER_ID = 'catPath' as const;
 
 export const useCatPathChooserBrowser = (): UseBrowserImplReturnValue => {
@@ -9,7 +10,8 @@ export const useCatPathChooserBrowser = (): UseBrowserImplReturnValue => {
     id: CAT_PATH_CHOOSER_BROWSER_ID,
     name: 'Category Path Chooser',
     content: <CatPathChooserBrowser value={value} onChange={setValue} />,
-    accept: () => value
+    accept: () => value,
+    icon: IvyIcons.Label
   };
 };
 

--- a/packages/editor/src/components/browser/CmsBrowser.tsx
+++ b/packages/editor/src/components/browser/CmsBrowser.tsx
@@ -31,7 +31,8 @@ export const useCmsBrowser = (onDoubleClick: () => void, options?: CmsOptions): 
         onDoubleClick={onDoubleClick}
       />
     ),
-    accept: () => value
+    accept: () => value,
+    icon: IvyIcons.Cms
   };
 };
 
@@ -64,7 +65,13 @@ const CmsBrowser = ({ value, onChange, noApiCall, typeFilter, onDoubleClick }: C
             <ExpandableCell
               cell={cell}
               title={cell.row.original.name}
-              icon={cell.row.original.type === 'FOLDER' ? IvyIcons.GoToSource : undefined}
+              icon={
+                cell.row.original.type === 'FOLDER'
+                  ? IvyIcons.FolderOpen
+                  : cell.row.original.type === 'FILE'
+                  ? IvyIcons.File
+                  : IvyIcons.ChangeType
+              }
               additionalInfo={cell.row.original.type}
             />
           );

--- a/packages/editor/src/components/browser/FunctionBrowser.tsx
+++ b/packages/editor/src/components/browser/FunctionBrowser.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react';
 import { Input } from '../widgets';
 import type { UseBrowserImplReturnValue } from './useBrowser';
+import { IvyIcons } from '@axonivy/editor-icons';
 export const FUNCTION_BROWSER_ID = 'func' as const;
 
 export const useFuncBrowser = (): UseBrowserImplReturnValue => {
   const [value, setValue] = useState('function');
-  return { id: FUNCTION_BROWSER_ID, name: 'Function', content: <FunctionBrowser value={value} onChange={setValue} />, accept: () => value };
+  return {
+    id: FUNCTION_BROWSER_ID,
+    name: 'Function',
+    content: <FunctionBrowser value={value} onChange={setValue} />,
+    accept: () => value,
+    icon: IvyIcons.Function
+  };
 };
 
 const FunctionBrowser = (props: { value: string; onChange: (value: string) => void }) => {

--- a/packages/editor/src/components/browser/SqlOperationBrowser.tsx
+++ b/packages/editor/src/components/browser/SqlOperationBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Input } from '../widgets';
 import type { UseBrowserImplReturnValue } from './useBrowser';
+import { IvyIcons } from '@axonivy/editor-icons';
 export const SQL_OPERATION_BROWSER_ID = 'sqlOp' as const;
 
 export const useSqlOpBrowser = (): UseBrowserImplReturnValue => {
@@ -9,7 +10,8 @@ export const useSqlOpBrowser = (): UseBrowserImplReturnValue => {
     id: SQL_OPERATION_BROWSER_ID,
     name: 'SQL Operation',
     content: <SqlOperationBrowser value={value} onChange={setValue} />,
-    accept: () => value
+    accept: () => value,
+    icon: IvyIcons.Task
   };
 };
 

--- a/packages/editor/src/components/browser/TableColBrowser.tsx
+++ b/packages/editor/src/components/browser/TableColBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Input } from '../widgets';
 import type { UseBrowserImplReturnValue } from './useBrowser';
+import { IvyIcons } from '@axonivy/editor-icons';
 export const TABLE_COL_BROWSER_ID = 'tablecol' as const;
 
 export const useTableColBrowser = (): UseBrowserImplReturnValue => {
@@ -9,7 +10,8 @@ export const useTableColBrowser = (): UseBrowserImplReturnValue => {
     id: TABLE_COL_BROWSER_ID,
     name: 'Table Column',
     content: <TableColumnBrowser value={value} onChange={setValue} />,
-    accept: () => value
+    accept: () => value,
+    icon: IvyIcons.Rule
   };
 };
 

--- a/packages/editor/src/components/browser/useBrowser.ts
+++ b/packages/editor/src/components/browser/useBrowser.ts
@@ -7,6 +7,7 @@ import type { TYPE_BROWSER_ID } from './TypeBrowser';
 import type { TABLE_COL_BROWSER_ID } from './TableColBrowser';
 import type { SQL_OPERATION_BROWSER_ID } from './SqlOperationBrowser';
 import type { CAT_PATH_CHOOSER_BROWSER_ID } from './CatPathChooser';
+import type { IvyIcons } from '@axonivy/editor-icons';
 
 export type BrowserType =
   | typeof ATTRIBUTE_BROWSER_ID
@@ -20,6 +21,7 @@ export type BrowserType =
 export type UseBrowserImplReturnValue = Omit<Tab, 'id'> & {
   id: BrowserType;
   accept: () => string;
+  icon: IvyIcons;
 };
 
 export type UseBrowserReturnValue = {

--- a/packages/editor/src/components/widgets/input/IconInput.tsx
+++ b/packages/editor/src/components/widgets/input/IconInput.tsx
@@ -3,19 +3,32 @@ import type { IvyIcons } from '@axonivy/editor-icons';
 import IvyIcon from '../IvyIcon';
 import type { InputProps } from './Input';
 import Input from './Input';
-import { forwardRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 export type IconInputProps = InputProps & {
   icon: IvyIcons;
+  initFocus?: boolean;
 };
 
-const IconInput = forwardRef<HTMLInputElement, IconInputProps>(({ icon, ...props }, forwardedRef) => {
+const IconInput = ({ icon, initFocus, ...props }: IconInputProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (initFocus) {
+      const timer = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+    return () => {};
+  }, [initFocus]);
+
   return (
     <div className='icon-input'>
       <IvyIcon icon={icon} />
-      <Input {...props} ref={forwardedRef} />
+      <Input {...props} ref={inputRef} />
     </div>
   );
-});
+};
 
 export default IconInput;

--- a/packages/editor/src/components/widgets/tab/Tab.css
+++ b/packages/editor/src/components/widgets/tab/Tab.css
@@ -24,6 +24,10 @@
   cursor: pointer;
   border-bottom: 1.5px solid var(--N500);
   flex: 1;
+  gap: var(--size-1);
+}
+.tabs-trigger:focus {
+  border: 1.5px solid var(--body);
 }
 .tabs-trigger:hover {
   border-bottom: 1.5px solid var(--body);
@@ -49,4 +53,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--size-3);
+}
+
+.tabs-trigger i {
+  font-size: 16px;
 }

--- a/packages/editor/src/components/widgets/tab/Tab.tsx
+++ b/packages/editor/src/components/widgets/tab/Tab.tsx
@@ -1,13 +1,16 @@
 import './Tab.css';
 import { Tabs as TabsRoot, TabsContent, TabsList, TabsTrigger } from '@radix-ui/react-tabs';
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import type { Message } from '../message/Message';
+import IvyIcon from '../IvyIcon';
+import type { IvyIcons } from '@axonivy/editor-icons';
 
 export type Tab = {
   id: string;
   name: string;
   messages?: Message[];
+  icon?: IvyIcons;
   content: ReactNode;
 };
 
@@ -36,7 +39,7 @@ export const TabRoot = ({ tabs, value, onChange, children }: TabsProps & { child
 export const TabList = ({ tabs }: TabsProps) => (
   <TabsList className='tabs-list'>
     {tabs.map((tab, index) => (
-      <TabTrigger key={`${index}-${tab.name}`} tab={tab} />
+      <TabTrigger key={`${index}-${tab.name}`} tab={tab} tabIcon={tab.icon} />
     ))}
   </TabsList>
 );
@@ -51,7 +54,7 @@ export const TabContent = ({ tabs }: TabsProps) => (
   </>
 );
 
-export const TabTrigger = ({ tab }: { tab: Tab }) => {
+export const TabTrigger = ({ tab, tabIcon }: { tab: Tab; tabIcon?: IvyIcons }) => {
   const state = useMemo(() => {
     if (tab.messages?.find(message => message.severity === 'ERROR')) {
       return 'error';
@@ -63,7 +66,7 @@ export const TabTrigger = ({ tab }: { tab: Tab }) => {
   }, [tab.messages]);
   return (
     <TabsTrigger className='tabs-trigger' data-message={state} value={tab.id}>
-      {tab.name}
+      {tabIcon && <IvyIcon icon={tabIcon} />} <div>{tab.name}</div>
     </TabsTrigger>
   );
 };

--- a/packages/editor/src/components/widgets/table/cell/ExpandableCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/ExpandableCell.tsx
@@ -31,7 +31,17 @@ export function ExpandableCell<TData>({
     row.toggleExpanded(true);
   };
   return (
-    <div className='row-expand' style={{ paddingLeft: `calc(${row.depth}*(var(--tree-gap))` }} title={title}>
+    <div
+      className='row-expand'
+      style={{
+        paddingLeft: `${
+          row.getCanExpand()
+            ? `calc(${row.depth} * var(--tree-gap))`
+            : `calc(${row.depth > 0 && icon ? '24px' : '0'} + ${row.depth} * var(--tree-gap))`
+        }`
+      }}
+      title={title}
+    >
       {row.getCanExpand() ? (
         <>
           <Button

--- a/packages/editor/src/components/widgets/table/table/Table.tsx
+++ b/packages/editor/src/components/widgets/table/table/Table.tsx
@@ -3,11 +3,14 @@ import './Table.css';
 import { IconInput } from '../../input';
 import { IvyIcons } from '@axonivy/editor-icons';
 
-type TableProps = { search?: { value: string; onChange: (value: string) => void }; children?: ReactNode };
+type TableProps = {
+  search?: { value: string; onChange: (value: string) => void };
+  children?: ReactNode;
+};
 
 export const Table = ({ search, children }: TableProps) => (
   <div className='table-root'>
-    {search && <IconInput icon={IvyIcons.Search} placeholder='Search' {...search} />}
+    {search && <IconInput icon={IvyIcons.Search} initFocus={true} placeholder='Search' {...search} />}
     <div className='table-container'>
       <table className='table'>{children}</table>
     </div>


### PR DESCRIPTION
Adjusted Typebrowser:
- By default, only the most frequently used types (ivytypes and a few others) and data classes are displayed (sorted alphabetically, first by full qualified name and then by simple name).
- There is now a checkbox "Search over all types." When this is activated, the search is conducted over all types and the ivytypes/dataclasses are no longer displayed; otherwise, the search is limited to data classes and ivytypes.
- Open ToDos: Reguel still needs to create metadata for the type browser so that in addition to data classes and ivytypes, own custom-created classes/types are also visible. It will also be nessesary that two icons are designed, to indicate whether the type is a data class, an Ivy type, or a "normal type." Possibly, an icon for the own custom classes might also make sense.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/7e59336a-a23c-4c61-9c83-171f58a350e0)

- Icons have been added to the known browser tabs.
- Icons have also been added to individual rows in the attribute/cms and type browser. The padding in the tree table of the CMS browser has also been improved.
- Initially, focus is always set on the search field.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/17daac00-231d-4228-9a39-f20d72fac936)
