### PR TITLE
XIVY-13052 Small monaoc fixes > R11.2

### DIFF
--- a/packages/editor/src/components/parts/output/OutputScriptPart.tsx
+++ b/packages/editor/src/components/parts/output/OutputScriptPart.tsx
@@ -5,6 +5,8 @@ import { Checkbox, ScriptArea, useFieldset } from '../../widgets';
 import { useOutputData } from './useOutputData';
 import { PathContext, useValidations } from '../../../context';
 import { PathFieldset } from '../common';
+import { splitNewLine } from '../../../utils/utils';
+import { useMemo } from 'react';
 
 export function useOutputScriptPart(): PartProps {
   const { config, defaultConfig, initConfig, resetCode } = useOutputData();
@@ -19,6 +21,14 @@ const OutputScriptPart = () => {
   const { config, update, updateSudo } = useOutputData();
   const codeFieldset = useFieldset();
 
+  const initHeight = useMemo(() => {
+    const height = splitNewLine(config.output.code).length * 18 + 20;
+    if (height < 90) {
+      return 90;
+    }
+    return height;
+  }, [config.output.code]);
+
   return (
     <PathContext path='output'>
       <PathFieldset label='Code' {...codeFieldset.labelProps} path='code'>
@@ -26,6 +36,7 @@ const OutputScriptPart = () => {
           value={config.output.code}
           onChange={change => update('code', change)}
           browsers={['attr', 'func', 'type', 'cms']}
+          initHeight={initHeight}
           {...codeFieldset.inputProps}
         />
       </PathFieldset>

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.css
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.css
@@ -1,7 +1,9 @@
+.code-editor {
+  background: var(--background);
+}
 .code-editor .code-input {
   border-radius: var(--border-radius);
   border: var(--basic-border);
-  background: var(--background);
   font-size: 12px;
   line-height: 12px;
   color: var(--body);

--- a/packages/editor/src/components/widgets/code-editor/ScriptArea.css
+++ b/packages/editor/src/components/widgets/code-editor/ScriptArea.css
@@ -22,3 +22,6 @@
 .script-area .button:hover {
   background-color: var(--N200);
 }
+.script-area:has(.monaco-editor .scrollbar.visible) .button {
+  z-index: 20;
+}

--- a/packages/editor/src/components/widgets/input/Textarea.tsx
+++ b/packages/editor/src/components/widgets/input/Textarea.tsx
@@ -2,6 +2,7 @@ import './Input.css';
 import type { ComponentProps } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useReadonly } from '../../../context';
+import { splitNewLine } from '../../../utils/utils';
 
 export type TextareaProps = Omit<ComponentProps<'textarea'>, 'value' | 'onChange'> & {
   value?: string;
@@ -21,7 +22,7 @@ const Textarea = ({ value, onChange, maxRows, disabled, ...textareaProps }: Text
   };
   const readonly = useReadonly();
   const height = useMemo(() => {
-    let rows = value?.split(/\r\n|\r|\n/).length ?? 1;
+    let rows = splitNewLine(value ?? '').length;
     if (maxRows && rows > maxRows) {
       rows = maxRows;
     }

--- a/packages/editor/src/components/widgets/popover/Popover.css
+++ b/packages/editor/src/components/widgets/popover/Popover.css
@@ -9,10 +9,6 @@
   color: var(--body);
   padding: var(--size-2);
 }
-.popover-content .script-input .code-editor .code-input .monaco-editor .view-lines,
-.popover-content .script-input .code-editor .code-input {
-  background-color: var(--background);
-}
 .popover-content:focus {
   box-shadow: var(--focus-shadow);
 }


### PR DESCRIPTION
- Fix monaco selection in popup
- Init height of script code block equals code
- Browser button in script-area should always be over scrollbar

master: https://github.com/axonivy/inscription-client/pull/447