### PR TITLE
XIVY-12992 Add ownType Meta to Typebrowser

### DIFF
--- a/packages/editor/src/components/browser/TypeBrowser.tsx
+++ b/packages/editor/src/components/browser/TypeBrowser.tsx
@@ -32,6 +32,7 @@ const TypeBrowser = (props: { value: string; onChange: (value: string) => void; 
   const { data: allDatatypes, isFetching } = useMeta('meta/scripting/allTypes', { context, limit: 150, type: mainFilter }, []);
   const dataClasses = useMeta('meta/scripting/dataClasses', context, []).data;
   const ivyTypes = useMeta('meta/scripting/ivyTypes', undefined, []).data;
+  const ownTypes = useMeta('meta/scripting/ownTypes', { context, limit: 100, type: '' }, []).data;
 
   const [types, setTypes] = useState<TypeBrowserObject[]>([]);
 
@@ -67,14 +68,22 @@ const TypeBrowser = (props: { value: string; onChange: (value: string) => void; 
         icon: IvyIcons.File,
         ...ivyType
       }));
+      const ownTypesWithoutDataClasses = ownTypes.filter(
+        ownType => !mappedDataClasses.find(dataClass => dataClass.fullQualifiedName === ownType.fullQualifiedName)
+      );
+      const mappedOwnTypes: TypeBrowserObject[] = ownTypesWithoutDataClasses.map<TypeBrowserObject>(ownType => ({
+        icon: IvyIcons.DataClass,
+        ...ownType
+      }));
 
       const sortedIvyTypes = mappedIvyTypes.sort(typeComparator);
       const sortedMappedDataClasses = mappedDataClasses.sort(typeComparator);
+      const sortedMappedOwnTypes = mappedOwnTypes.sort(typeComparator);
 
-      const sortedTypes: TypeBrowserObject[] = sortedMappedDataClasses.concat(sortedIvyTypes);
+      const sortedTypes: TypeBrowserObject[] = sortedMappedOwnTypes.concat(sortedMappedDataClasses).concat(sortedIvyTypes);
       setTypes(sortedTypes);
     }
-  }, [allDatatypes, allSearchActive, dataClasses, ivyTypes, mainFilter]);
+  }, [allDatatypes, allSearchActive, dataClasses, ivyTypes, mainFilter, ownTypes]);
 
   useEffect(() => {
     setRowSelection({});

--- a/packages/protocol/src/inscription-protocol.ts
+++ b/packages/protocol/src/inscription-protocol.ts
@@ -74,6 +74,7 @@ export interface InscriptionMetaRequestTypes {
   'meta/scripting/dataClasses': [InscriptionContext, DataClass[]];
   'meta/scripting/allTypes': [TypeSearchRequest, JavaType[]];
   'meta/scripting/ivyTypes': [void, JavaType[]];
+  'meta/scripting/ownTypes': [TypeSearchRequest, JavaType[]];
 
   'meta/program/types': [ProgramInterfacesRequest, ProgramInterface[]];
   'meta/program/editor': [ProgramEditorRequest, Widget[]];


### PR DESCRIPTION
I added the new 'ownType-Meta' so that now in the type browser, first all ownTypes are displayed, followed by DataClasses, and finally IvyTypes, including commonly used types. Additionally, I had to remove all data classes from ownTypes.data to avoid duplicates. The Icons are not perfect yet, still need to adress this to Anais.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/7057114d-36f7-4365-8c42-b81f83d7e36d)
