### PR TITLE
XIVY-12992 Fix defaulttypes for typebrowser

### DIFF
--- a/packages/editor/src/components/browser/AttributeBrowser.test.tsx
+++ b/packages/editor/src/components/browser/AttributeBrowser.test.tsx
@@ -2,6 +2,7 @@ import type { VariableInfo } from '@axonivy/inscription-protocol';
 import { TableUtil, render, screen, userEvent } from 'test-utils';
 import { useAttributeBrowser } from './AttributeBrowser';
 import { describe, test, expect } from 'vitest';
+import type { BrowserValue } from './Browser';
 
 const TYPES = {
   'mock.Test': [
@@ -64,7 +65,7 @@ const OUT_VAR_INFO: VariableInfo = {
   types: TYPES
 };
 
-const Browser = (props: { location: string; accept: (value: string) => void }) => {
+const Browser = (props: { location: string; accept: (value: BrowserValue) => void }) => {
   const browser = useAttributeBrowser(() => {}, props.location);
   return (
     <>
@@ -75,7 +76,7 @@ const Browser = (props: { location: string; accept: (value: string) => void }) =
 };
 
 describe('AttributeBrowser', () => {
-  function renderBrowser(options?: { location?: string; accept?: (value: string) => void }) {
+  function renderBrowser(options?: { location?: string; accept?: (value: BrowserValue) => void }) {
     render(<Browser location={options?.location ?? 'something'} accept={options?.accept ?? (() => {})} />, {
       wrapperProps: { meta: { inScripting: IN_VAR_INFO, outScripting: OUT_VAR_INFO } }
     });
@@ -95,7 +96,7 @@ describe('AttributeBrowser', () => {
 
   test('accept', async () => {
     let data = '';
-    renderBrowser({ accept: value => (data = value) });
+    renderBrowser({ accept: value => (data = value.cursorValue) });
     await userEvent.click(await screen.findByText('user', { selector: 'span.row-expand-label' }));
     await userEvent.click(screen.getByTestId('accept'));
     expect(data).toEqual('in.user');

--- a/packages/editor/src/components/browser/AttributeBrowser.tsx
+++ b/packages/editor/src/components/browser/AttributeBrowser.tsx
@@ -8,16 +8,17 @@ import type { VariableInfo } from '@axonivy/inscription-protocol';
 import { useEditorContext, useMeta } from '../../context';
 import { calcFullPathId } from '../parts/common/mapping-tree/useMappingTree';
 import { IvyIcons } from '@axonivy/editor-icons';
+import type { BrowserValue } from './Browser';
 
 export const ATTRIBUTE_BROWSER_ID = 'attr' as const;
 
 export const useAttributeBrowser = (onDoubleClick: () => void, location: string): UseBrowserImplReturnValue => {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState<BrowserValue>({ cursorValue: '' });
   return {
     id: ATTRIBUTE_BROWSER_ID,
     icon: IvyIcons.Attribute,
     name: 'Attribute',
-    content: <AttributeBrowser value={value} onChange={setValue} location={location} onDoubleClick={onDoubleClick} />,
+    content: <AttributeBrowser value={value.cursorValue} onChange={setValue} location={location} onDoubleClick={onDoubleClick} />,
     accept: () => value
   };
 };
@@ -29,7 +30,7 @@ const AttributeBrowser = ({
   onDoubleClick
 }: {
   value: string;
-  onChange: (value: string) => void;
+  onChange: (value: BrowserValue) => void;
   location: string;
   onDoubleClick: () => void;
 }) => {
@@ -109,7 +110,7 @@ const AttributeBrowser = ({
     }
     const selectedRow = table.getRowModel().rowsById[Object.keys(rowSelection)[0]];
     setShowHelper(true);
-    onChange(calcFullPathId(selectedRow));
+    onChange({ cursorValue: calcFullPathId(selectedRow) });
   }, [onChange, rowSelection, table]);
 
   return (

--- a/packages/editor/src/components/browser/Browser.tsx
+++ b/packages/editor/src/components/browser/Browser.tsx
@@ -14,9 +14,11 @@ import { useCatPathChooserBrowser } from './CatPathChooser';
 import type { CmsOptions } from './CmsBrowser';
 import { useCmsBrowser } from './CmsBrowser';
 
+export type BrowserValue = { cursorValue: string; firstLineValue?: string };
+
 type BrowserProps = UseBrowserReturnValue & {
   types: BrowserType[];
-  accept: (value: string, type: BrowserType) => void;
+  accept: (value: BrowserValue, type: BrowserType) => void;
   location: string;
   cmsOptions?: CmsOptions;
   initSearchFilter?: () => string;
@@ -27,7 +29,7 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, init
   const [active, setActive] = useState<BrowserType>(types[0]);
 
   const acceptBrowser = () => {
-    accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? '', active);
+    accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? { cursorValue: '' }, active);
   };
 
   const onRowDoubleClick = () => {
@@ -44,7 +46,8 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, init
       ? initSearchFilter
       : () => {
           return '';
-        }
+        },
+    location
   );
   const catPathChooserBrowser = useCatPathChooserBrowser();
   const tableColBrowser = useTableColBrowser();

--- a/packages/editor/src/components/browser/CatPathChooser.tsx
+++ b/packages/editor/src/components/browser/CatPathChooser.tsx
@@ -2,14 +2,15 @@ import { useState } from 'react';
 import { Input } from '../widgets';
 import type { UseBrowserImplReturnValue } from './useBrowser';
 import { IvyIcons } from '@axonivy/editor-icons';
+import type { BrowserValue } from './Browser';
 export const CAT_PATH_CHOOSER_BROWSER_ID = 'catPath' as const;
 
 export const useCatPathChooserBrowser = (): UseBrowserImplReturnValue => {
-  const [value, setValue] = useState('category path chooser');
+  const [value, setValue] = useState<BrowserValue>({ cursorValue: 'category path chooser' });
   return {
     id: CAT_PATH_CHOOSER_BROWSER_ID,
     name: 'Category Path Chooser',
-    content: <CatPathChooserBrowser value={value} onChange={setValue} />,
+    content: <CatPathChooserBrowser value={value.cursorValue} onChange={(change: string) => setValue({ cursorValue: change })} />,
     accept: () => value,
     icon: IvyIcons.Label
   };

--- a/packages/editor/src/components/browser/CmsBrowser.test.tsx
+++ b/packages/editor/src/components/browser/CmsBrowser.test.tsx
@@ -1,8 +1,9 @@
 import { TableUtil, render, screen, userEvent } from 'test-utils';
 import { useCmsBrowser } from './CmsBrowser';
 import { describe, test, expect } from 'vitest';
+import type { BrowserValue } from './Browser';
 
-const Browser = (props: { location: string; accept: (value: string) => void }) => {
+const Browser = (props: { location: string; accept: (value: BrowserValue) => void }) => {
   const browser = useCmsBrowser(() => {}, props.location);
   return (
     <>
@@ -13,7 +14,7 @@ const Browser = (props: { location: string; accept: (value: string) => void }) =
 };
 
 describe('CmsBrowser', () => {
-  function renderBrowser(options?: { location?: string; accept?: (value: string) => void }) {
+  function renderBrowser(options?: { location?: string; accept?: (value: BrowserValue) => void }) {
     render(<Browser location={options?.location ?? 'something'} accept={options?.accept ?? (() => {})} />, {
       wrapperProps: {
         meta: {
@@ -47,7 +48,7 @@ describe('CmsBrowser', () => {
 
   test('accept', async () => {
     let data = '';
-    renderBrowser({ accept: value => (data = value) });
+    renderBrowser({ accept: value => (data = value.cursorValue) });
     await userEvent.click(await screen.findByRole('cell', { name: 'Macro' }));
     await userEvent.click(screen.getByTestId('accept'));
     expect(data).toEqual('ivy.cms.co("/Macro")');
@@ -55,7 +56,7 @@ describe('CmsBrowser', () => {
 
   test('file', async () => {
     let data = '';
-    renderBrowser({ accept: value => (data = value) });
+    renderBrowser({ accept: value => (data = value.cursorValue) });
     await userEvent.click(await screen.findByRole('cell', { name: 'CoolFile' }));
     await userEvent.click(screen.getByTestId('accept'));
     expect(data).toEqual('ivy.cms.cr("/CoolFile")');
@@ -63,14 +64,14 @@ describe('CmsBrowser', () => {
 
   test('file in mail attachments', async () => {
     let data = '';
-    renderBrowser({ accept: value => (data = value), location: 'attachments' });
+    renderBrowser({ accept: value => (data = value.cursorValue), location: 'attachments' });
     await userEvent.click(await screen.findByRole('cell', { name: 'CoolFile' }));
     await userEvent.click(screen.getByTestId('accept'));
     expect(data).toEqual('ivy.cm.findObject("/CoolFile")');
   });
   test('file in mail content', async () => {
     let data = '';
-    renderBrowser({ accept: value => (data = value), location: 'message' });
+    renderBrowser({ accept: value => (data = value.cursorValue), location: 'message' });
     await userEvent.click(await screen.findByRole('cell', { name: 'CoolFile' }));
     await userEvent.click(screen.getByTestId('accept'));
     expect(data).toEqual('ivy.cms.co("/CoolFile")');

--- a/packages/editor/src/components/browser/CmsBrowser.tsx
+++ b/packages/editor/src/components/browser/CmsBrowser.tsx
@@ -6,6 +6,7 @@ import type { ColumnDef, ColumnFiltersState, ExpandedState, RowSelectionState, V
 import { flexRender, getCoreRowModel, getExpandedRowModel, getFilteredRowModel, useReactTable } from '@tanstack/react-table';
 import type { ContentObject, ContentObjectType } from '@axonivy/inscription-protocol';
 import { IvyIcons } from '@axonivy/editor-icons';
+import type { BrowserValue } from './Browser';
 
 export const CMS_BROWSER_ID = 'cms' as const;
 
@@ -17,14 +18,14 @@ export type CmsOptions = {
 };
 
 export const useCmsBrowser = (onDoubleClick: () => void, location: string, options?: CmsOptions): UseBrowserImplReturnValue => {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState<BrowserValue>({ cursorValue: '' });
 
   return {
     id: CMS_BROWSER_ID,
     name: 'CMS',
     content: (
       <CmsBrowser
-        value={value}
+        value={value.cursorValue}
         onChange={setValue}
         noApiCall={options?.noApiCall}
         typeFilter={options?.typeFilter}
@@ -39,7 +40,7 @@ export const useCmsBrowser = (onDoubleClick: () => void, location: string, optio
 
 interface CmsBrowserProps {
   value: string;
-  onChange: (value: string) => void;
+  onChange: (value: BrowserValue) => void;
   noApiCall?: boolean;
   typeFilter?: CmsTypeFilter;
   onDoubleClick: () => void;
@@ -142,13 +143,13 @@ const CmsBrowser = ({ value, onChange, noApiCall, typeFilter, onDoubleClick, loc
     if (Object.keys(rowSelection).length !== 1) {
       setSelectedContentObject({ name: '', children: [], fullPath: '', type: 'STRING', values: {} });
       setShowHelper(false);
-      onChange('');
+      onChange({ cursorValue: '' });
       return;
     }
     const selectedRow = table.getRowModel().rowsById[Object.keys(rowSelection)[0]];
     setSelectedContentObject(selectedRow.original);
     setShowHelper(true);
-    onChange(addIvyPathToValue(selectedRow.original.fullPath, selectedRow.original.type, noApiCall));
+    onChange({ cursorValue: addIvyPathToValue(selectedRow.original.fullPath, selectedRow.original.type, noApiCall) });
   }, [onChange, rowSelection, noApiCall, table, location]);
 
   return (

--- a/packages/editor/src/components/browser/FunctionBrowser.tsx
+++ b/packages/editor/src/components/browser/FunctionBrowser.tsx
@@ -14,21 +14,22 @@ import {
   type Row
 } from '@tanstack/react-table';
 import { IvyIcons } from '@axonivy/editor-icons';
+import type { BrowserValue } from './Browser';
 import { useEditorContext, useMeta } from '../../context';
 export const FUNCTION_BROWSER_ID = 'func' as const;
 
 export const useFuncBrowser = (onDoubleClick: () => void): UseBrowserImplReturnValue => {
-  const [value, setValue] = useState('function');
+  const [value, setValue] = useState<BrowserValue>({ cursorValue: '' });
   return {
     id: FUNCTION_BROWSER_ID,
     name: 'Function',
-    content: <FunctionBrowser value={value} onChange={setValue} onDoubleClick={onDoubleClick} />,
+    content: <FunctionBrowser value={value.cursorValue} onChange={setValue} onDoubleClick={onDoubleClick} />,
     accept: () => value,
     icon: IvyIcons.Function
   };
 };
 
-const FunctionBrowser = (props: { value: string; onChange: (value: string) => void; onDoubleClick: () => void }) => {
+const FunctionBrowser = (props: { value: string; onChange: (value: BrowserValue) => void; onDoubleClick: () => void }) => {
   const { context } = useEditorContext();
   const [method, setMethod] = useState('');
   const [paramTypes, setParamTypes] = useState<string[]>([]);
@@ -101,7 +102,7 @@ const FunctionBrowser = (props: { value: string; onChange: (value: string) => vo
 
     if (Object.keys(rowSelection).length !== 1) {
       setShowHelper(false);
-      props.onChange('');
+      props.onChange({ cursorValue: '' });
       return;
     }
     const selectedRow = table.getRowModel().rowsById[Object.keys(rowSelection)[0]];
@@ -109,11 +110,11 @@ const FunctionBrowser = (props: { value: string; onChange: (value: string) => vo
     //setup correct functionName for the accept-method
     const parentNames = getParentNames(selectedRow);
     const selectedName = parentNames.reverse().join('.');
-    props.onChange(
-      selectedRow.original.isField
+    props.onChange({
+      cursorValue: selectedRow.original.isField
         ? selectedName
         : selectedName + '(' + selectedRow.original.params.map(param => param.type.split('.').pop()).join(', ') + ')'
-    );
+    });
 
     //setup Meta-Call for docApi
     const parentRow = selectedRow.getParentRow();

--- a/packages/editor/src/components/browser/SqlOperationBrowser.tsx
+++ b/packages/editor/src/components/browser/SqlOperationBrowser.tsx
@@ -2,14 +2,15 @@ import { useState } from 'react';
 import { Input } from '../widgets';
 import type { UseBrowserImplReturnValue } from './useBrowser';
 import { IvyIcons } from '@axonivy/editor-icons';
+import type { BrowserValue } from './Browser';
 export const SQL_OPERATION_BROWSER_ID = 'sqlOp' as const;
 
 export const useSqlOpBrowser = (): UseBrowserImplReturnValue => {
-  const [value, setValue] = useState('sql operation');
+  const [value, setValue] = useState<BrowserValue>({ cursorValue: 'sql operation' });
   return {
     id: SQL_OPERATION_BROWSER_ID,
     name: 'SQL Operation',
-    content: <SqlOperationBrowser value={value} onChange={setValue} />,
+    content: <SqlOperationBrowser value={value.cursorValue} onChange={(change: string) => setValue({ cursorValue: change })} />,
     accept: () => value,
     icon: IvyIcons.Task
   };

--- a/packages/editor/src/components/browser/TableColBrowser.tsx
+++ b/packages/editor/src/components/browser/TableColBrowser.tsx
@@ -2,14 +2,15 @@ import { useState } from 'react';
 import { Input } from '../widgets';
 import type { UseBrowserImplReturnValue } from './useBrowser';
 import { IvyIcons } from '@axonivy/editor-icons';
+import type { BrowserValue } from './Browser';
 export const TABLE_COL_BROWSER_ID = 'tablecol' as const;
 
 export const useTableColBrowser = (): UseBrowserImplReturnValue => {
-  const [value, setValue] = useState('table column');
+  const [value, setValue] = useState<BrowserValue>({ cursorValue: 'table column' });
   return {
     id: TABLE_COL_BROWSER_ID,
     name: 'Table Column',
-    content: <TableColumnBrowser value={value} onChange={setValue} />,
+    content: <TableColumnBrowser value={value.cursorValue} onChange={(change: string) => setValue({ cursorValue: change })} />,
     accept: () => value,
     icon: IvyIcons.Rule
   };

--- a/packages/editor/src/components/browser/typeBrowser-utils.test.ts
+++ b/packages/editor/src/components/browser/typeBrowser-utils.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest';
+import { getCursorValue } from './typeBrowser-utils'; // Update the path accordingly
+import type { TypeBrowserObject } from './TypeBrowser';
+import { IvyIcons } from '@axonivy/editor-icons';
+
+const value: TypeBrowserObject = {
+  simpleName: 'SampleType',
+  fullQualifiedName: 'com.example.SampleType',
+  icon: IvyIcons.ActivitiesGroup,
+  packageName: 'com.example'
+};
+
+test('getCursorValue handles IvyType and typeAsList and inCodeBlock', () => {
+  expect(getCursorValue(value, true, true, true)).toEqual('List<SampleType>');
+});
+
+test('getCursorValue handles IvyType, typeAsList, and not inCodeBlock', () => {
+  expect(getCursorValue(value, true, true, false)).toEqual('java.util.List<SampleType>');
+});
+
+test('getCursorValue handles IvyType, non-typeAsList, and inCodeBlock', () => {
+  expect(getCursorValue(value, true, false, true)).toEqual('SampleType');
+});
+
+test('getCursorValue handles no IvyType, typeAsList, and inCodeBlock', () => {
+  expect(getCursorValue(value, false, true, true)).toEqual('List<com.example.SampleType>');
+});
+
+test('getCursorValue handles non-IvyType and non-typeAsList', () => {
+  expect(getCursorValue(value, false, false, true)).toEqual('com.example.SampleType');
+});
+
+test('getCursorValue handles IvyType, not-typeAsList, and not inCodeBlock', () => {
+  expect(getCursorValue(value, true, false, false)).toEqual('SampleType');
+});
+
+test('getCursorValue handles non-IvyType, typeAsList, and not inCodeBlock', () => {
+  expect(getCursorValue(value, false, true, false)).toEqual('java.util.List<com.example.SampleType>');
+});
+
+test('getCursorValue handles non-IvyType and non-typeAsList and not inCodeBlock', () => {
+  expect(getCursorValue(value, false, false, false)).toEqual('com.example.SampleType');
+});
+
+// Add more test cases for other scenarios

--- a/packages/editor/src/components/browser/typeBrowser-utils.ts
+++ b/packages/editor/src/components/browser/typeBrowser-utils.ts
@@ -1,0 +1,17 @@
+import type { TypeBrowserObject } from './TypeBrowser';
+
+const addListGeneric = (value: string, inCodeBlock: boolean) => {
+  let listPrefix = 'java.util.List';
+  if (inCodeBlock) {
+    listPrefix = 'List';
+  }
+  return `${listPrefix}<${value}>`;
+};
+
+export const getCursorValue = (value: TypeBrowserObject, isIvyType: boolean, typeAsList: boolean, inCodeBlock: boolean) => {
+  if (isIvyType) {
+    return typeAsList ? addListGeneric(value.simpleName, inCodeBlock) : value.simpleName;
+  } else {
+    return typeAsList ? addListGeneric(value.fullQualifiedName, inCodeBlock) : value.fullQualifiedName;
+  }
+};

--- a/packages/editor/src/components/browser/useBrowser.ts
+++ b/packages/editor/src/components/browser/useBrowser.ts
@@ -18,9 +18,11 @@ export type BrowserType =
   | typeof TABLE_COL_BROWSER_ID
   | typeof SQL_OPERATION_BROWSER_ID;
 
+type BrowserValue = { cursorValue: string; firstLineValue?: string };
+
 export type UseBrowserImplReturnValue = Omit<Tab, 'id'> & {
   id: BrowserType;
-  accept: () => string;
+  accept: () => BrowserValue;
   icon: IvyIcons;
 };
 

--- a/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
+++ b/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import type { BrowserType } from '../../../components/browser';
+import type { BrowserValue } from '../../browser/Browser';
+import type { BrowserType } from '../../browser';
 
 export const monacoAutoFocus = (editor: monaco.editor.IStandaloneCodeEditor) => {
   const range = editor.getModel()?.getFullModelRange();
@@ -15,7 +16,7 @@ export type ModifyAction = (value: string) => string;
 export const useMonacoEditor = (options?: { modifyAction?: ModifyAction; scriptAreaDatatypeEditor?: boolean }) => {
   const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor>();
 
-  const modifyEditor = (value: string, type: BrowserType) => {
+  const modifyEditor = (value: BrowserValue, type: BrowserType) => {
     if (!editor) {
       return;
     }
@@ -23,21 +24,21 @@ export const useMonacoEditor = (options?: { modifyAction?: ModifyAction; scriptA
     if (!selection) {
       return;
     }
-
-    if (type === 'type' && options?.scriptAreaDatatypeEditor) {
-      const textWithLineBreak = 'import ' + value + ';\n';
-      const parts = value.split('.');
-      const shortValue = parts.length > 1 ? parts.pop() : value;
+    if (value.firstLineValue) {
       editor.executeEdits('browser', [
-        { range: editor.getModel()?.getFullModelRange().collapseToStart() ?? selection, text: textWithLineBreak, forceMoveMarkers: true },
+        {
+          range: editor.getModel()?.getFullModelRange().collapseToStart() ?? selection,
+          text: value.firstLineValue ? value.firstLineValue : '',
+          forceMoveMarkers: true
+        },
         {
           range: selection,
-          text: shortValue || '',
+          text: value.cursorValue,
           forceMoveMarkers: true
         }
       ]);
     } else {
-      const text = value.length > 0 && options?.modifyAction ? options.modifyAction(value) : value;
+      const text = value.cursorValue.length > 0 && options?.modifyAction ? options.modifyAction(value.cursorValue) : value.cursorValue;
       editor.executeEdits('browser', [{ range: selection, text, forceMoveMarkers: true }]);
       if (type === 'func') {
         const updatedEditorContent = editor.getValue();

--- a/packages/editor/src/components/widgets/combobox/Combobox.tsx
+++ b/packages/editor/src/components/widgets/combobox/Combobox.tsx
@@ -11,6 +11,7 @@ import type { BrowserType } from '../../../components/browser';
 import { Browser, useBrowser } from '../../../components/browser';
 import { CardText } from '../output/CardText';
 import { useOnFocus } from '../../../components/browser/useOnFocus';
+import type { BrowserValue } from '../../browser/Browser';
 
 export interface ComboboxItem {
   value: string;
@@ -116,7 +117,12 @@ const Combobox = <T extends ComboboxItem>({
           disabled={readonly}
         />
         {browserTypes || (macro && browserTypes!) ? (
-          <Browser {...browser} types={browserTypes ? browserTypes : ['attr']} accept={macro ? modifyEditor : onChange} location={path} />
+          <Browser
+            {...browser}
+            types={browserTypes ? browserTypes : ['attr']}
+            accept={macro ? modifyEditor : (change: BrowserValue) => onChange(change.cursorValue)}
+            location={path}
+          />
         ) : null}
       </div>
       <ul {...getMenuProps()} className='combobox-menu'>

--- a/packages/editor/src/components/widgets/input/InputWithBrowser.tsx
+++ b/packages/editor/src/components/widgets/input/InputWithBrowser.tsx
@@ -1,10 +1,11 @@
 import './Input.css';
-import type { BrowserType} from '../../../components/browser';
+import type { BrowserType } from '../../../components/browser';
 import { Browser, useBrowser } from '../../../components/browser';
 import { usePath } from '../../../context';
 import type { ComponentProps } from 'react';
 import Input from './Input';
 import type { CmsTypeFilter } from '../../../components/browser/CmsBrowser';
+import type { BrowserValue } from '../../browser/Browser';
 
 type InputWithBrowserProps = Omit<ComponentProps<'input'>, 'value' | 'onChange' | 'ref'> & {
   value?: string;
@@ -20,7 +21,13 @@ const InputWithBrowser = ({ value, onChange, disabled, browsers, typeFilter, ...
   return (
     <div className='input-with-browser'>
       <Input value={value as string} onChange={onChange} disabled={disabled} {...props} />
-      <Browser {...browser} types={browsers} cmsOptions={{ noApiCall: true, typeFilter: typeFilter }} accept={onChange} location={path} />
+      <Browser
+        {...browser}
+        types={browsers}
+        cmsOptions={{ noApiCall: true, typeFilter: typeFilter }}
+        accept={(change: BrowserValue) => onChange(change.cursorValue)}
+        location={path}
+      />
     </div>
   );
 };

--- a/packages/editor/src/test-utils/test-utils.tsx
+++ b/packages/editor/src/test-utils/test-utils.tsx
@@ -75,6 +75,7 @@ type ContextHelperProps = {
     widgets?: Widget[];
     contentObject?: ContentObject[];
     datatypes?: JavaType[];
+    ivyTypes?: JavaType[];
     dataClasses?: DataClass[];
   };
   editor?: { title?: string; readonly?: boolean };
@@ -172,8 +173,8 @@ const ContextHelper = (
             return Promise.resolve(props.meta?.widgets ?? []);
           case 'meta/cms/tree':
             return Promise.resolve(props.meta?.contentObject ?? []);
-          case 'meta/scripting/allTypes':
-            return Promise.resolve(props.meta?.javaClasses ?? []);
+          case 'meta/scripting/ivyTypes':
+            return Promise.resolve(props.meta?.ivyTypes ?? []);
           case 'meta/scripting/dataClasses':
             return Promise.resolve(props.meta?.dataClasses ?? []);
           default:


### PR DESCRIPTION
Modified the default types in the Typebrowser as follows:
- Within code blocks, the default types are prioritized in the following order: 1. Own Types, 2. Data Classes, 3. Ivy Types (with the condition that, if applied, there should be no "import..." statement and also sorted alphabetically but all elements from java.lang/util should be displayed first).
- In all other sections, particularly in the mapping table, the default types are ordered as follows: 1. Data Classes, 2. Ivy Types.