### PR TITLE
XIVY-12992 Fix ParameterTable with browser

### DIFF
--- a/packages/editor/src/components/widgets/table/cell/EditableCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/EditableCell.tsx
@@ -35,7 +35,7 @@ export function EditableCell<TData>({ cell, disabled, withBrowser: propWithBrows
       {isFocusWithin || browser.open ? (
         <>
           <Input {...focusValue} value={value as string} onChange={change => setValue(change)} onBlur={onBlur} disabled={disabled} />
-          <Browser {...browser} types={['type']} accept={change => setValue(change)} location={path} />
+          <Browser {...browser} types={['type']} accept={change => setValue(change.cursorValue)} location={path} />
         </>
       ) : (
         <Input value={value as string} onChange={change => setValue(change)} onBlur={onBlur} disabled={disabled} />


### PR DESCRIPTION
When adding a type from the browser using the ParameterTable for input parameters, only [Object object] appeared instead of the actual type. This occurred because I am now working not only with strings but also with the BrowserValue object. This adjustment ensures that the table functions smoothly again.