### PR TITLE
XIVY-12992 Fix EditableCell with Browser

### DIFF
--- a/packages/editor/src/components/widgets/table/cell/EditableCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/EditableCell.tsx
@@ -23,19 +23,26 @@ export function EditableCell<TData>({ cell, disabled, withBrowser: propWithBrows
   const path = usePath();
   const withBrowser = propWithBrowser || false;
   const { isFocusWithin, focusWithinProps, focusValue } = useOnFocus(value as string, change => setValue(change));
+
   const onBlur = () => {
     cell.table.options.meta?.updateData(cell.row.id, cell.column.id, value);
   };
+
   useEffect(() => {
     setValue(initialValue);
   }, [initialValue]);
+
+  const updateValue = (value: string) => {
+    setValue(value);
+    cell.table.options.meta?.updateData(cell.row.id, cell.column.id, value);
+  };
 
   return withBrowser ? (
     <div className='editableCell-with-browser' {...focusWithinProps} tabIndex={1}>
       {isFocusWithin || browser.open ? (
         <>
           <Input {...focusValue} value={value as string} onChange={change => setValue(change)} onBlur={onBlur} disabled={disabled} />
-          <Browser {...browser} types={['type']} accept={change => setValue(change.cursorValue)} location={path} />
+          <Browser {...browser} types={['type']} accept={change => updateValue(change.cursorValue)} location={path} />
         </>
       ) : (
         <Input value={value as string} onChange={change => setValue(change)} onBlur={onBlur} disabled={disabled} />


### PR DESCRIPTION
The problem was that the onBlur function was not being triggerd again after the accept of the browser, causing the table's meta not to be updated. Consequently, upon refreshing the component, the old value was displayed again. It worked perfectly if the type was entered directly into the input field, but it didn't work when the type was supposed to be defined using the typebrowser. Now, it should work as intended.