### PR TITLE
XIVY-12797 Add open with f2 and adopt cursorPosition/selection feature

### DIFF
--- a/packages/editor/src/components/browser/MaximizedCodeEditorBrowser.tsx
+++ b/packages/editor/src/components/browser/MaximizedCodeEditorBrowser.tsx
@@ -1,16 +1,11 @@
 import { Dialog } from '@radix-ui/react-dialog';
 import { type Tab } from '../widgets';
-import { type BrowserType, type UseBrowserReturnValue } from './useBrowser';
+import { type UseBrowserReturnValue } from './useBrowser';
 import { IvyIcons } from '@axonivy/editor-icons';
+import MaximizedCodeEditor, { type MaximizedCodeEditorProps } from './maximizedCodeEditor/MaximizedCodeEditor';
 import BrowserBody from './BrowserBody';
-import MaximizedCodeEditor from './maximizedCodeEditor/MaximizedCodeEditor';
 
-type MaximaziedCodeEditorBrowserProps = UseBrowserReturnValue & {
-  editorValue: string;
-  location: string;
-  browsers: BrowserType[];
-  applyEditor: (change: string) => void;
-};
+type MaximaziedCodeEditorBrowserProps = UseBrowserReturnValue & MaximizedCodeEditorProps;
 
 const MaximizedCodeEditorBrowser = ({
   open,
@@ -18,11 +13,25 @@ const MaximizedCodeEditorBrowser = ({
   browsers,
   editorValue,
   applyEditor,
-  location
+  location,
+  selectionRange
 }: MaximaziedCodeEditorBrowserProps) => {
   const tabs: Tab[] = [
     {
-      content: <MaximizedCodeEditor applyEditor={applyEditor} browsers={browsers} editorValue={editorValue} location={location} />,
+      content: (
+        <MaximizedCodeEditor
+          applyEditor={applyEditor}
+          browsers={browsers}
+          editorValue={editorValue}
+          location={location}
+          selectionRange={selectionRange}
+          keyActions={{
+            escape: () => {
+              onOpenChange(false);
+            }
+          }}
+        />
+      ),
       id: 'maxCode',
       name: 'Code',
       icon: IvyIcons.StartProgram

--- a/packages/editor/src/components/browser/maximizedCodeEditor/MaximizedCodeEditor.tsx
+++ b/packages/editor/src/components/browser/maximizedCodeEditor/MaximizedCodeEditor.tsx
@@ -1,20 +1,38 @@
 import './MaximizedCodeEditor.css';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { useBrowser, type BrowserType } from '../useBrowser';
-import { useMonacoEditor } from '../../widgets/code-editor/useCodeEditor';
+import { monacoAutoFocus, useMonacoEditor } from '../../widgets/code-editor/useCodeEditor';
 import CodeEditor from '../../widgets/code-editor/CodeEditor';
 import Browser from '../Browser';
 import { MAXIMIZED_MONACO_OPTIONS } from '../../../monaco/monaco-editor-util';
 
-type MaximizedCodeEditorProps = {
+export type MaximizedCodeEditorProps = {
   editorValue: string;
   location: string;
   browsers: BrowserType[];
   applyEditor: (change: string) => void;
+  selectionRange: monaco.IRange | null;
+  keyActions?: {
+    escape?: () => void;
+  };
 };
 
-const MaximizedCodeEditor = ({ editorValue, location, browsers, applyEditor }: MaximizedCodeEditorProps) => {
-  const { setEditor, modifyEditor, getMonacoSelection } = useMonacoEditor({ scriptAreaDatatypeEditor: true });
+const MaximizedCodeEditor = ({ editorValue, location, browsers, applyEditor, selectionRange, keyActions }: MaximizedCodeEditorProps) => {
+  const { setEditor, modifyEditor, getMonacoSelection } = useMonacoEditor();
   const browser = useBrowser();
+
+  const setSelection = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    if (selectionRange !== null) {
+      editor.setSelection(selectionRange);
+    }
+  };
+  const keyActionMountFunc = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    editor.addCommand(monaco.KeyCode.Escape, () => {
+      if (keyActions?.escape) {
+        keyActions.escape();
+      }
+    });
+  };
 
   return (
     <div className='maximized-script-area'>
@@ -23,7 +41,7 @@ const MaximizedCodeEditor = ({ editorValue, location, browsers, applyEditor }: M
           value={editorValue}
           onChange={applyEditor}
           context={{ location }}
-          onMountFuncs={[setEditor]}
+          onMountFuncs={[setEditor, monacoAutoFocus, setSelection, keyActionMountFunc]}
           options={MAXIMIZED_MONACO_OPTIONS}
         />
       </div>

--- a/packages/editor/src/components/widgets/code-editor/ResizableCodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ResizableCodeEditor.tsx
@@ -28,7 +28,6 @@ const ResizableCodeEditor = ({ initHeight, location, ...props }: ResizableCodeEd
       setResizeActive(false);
     }
   });
-
   return (
     <div className='resizable-code-editor'>
       <CodeEditor {...props} context={{ location }} height={height} />

--- a/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
@@ -1,4 +1,5 @@
 import './ScriptArea.css';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import type { CodeEditorAreaProps } from './ResizableCodeEditor';
 import ResizableCodeEditor from './ResizableCodeEditor';
 import { Browser, useBrowser } from '../../../components/browser';
@@ -15,8 +16,13 @@ type ScriptAreaProps = CodeEditorAreaProps & {
 
 const ScriptArea = (props: ScriptAreaProps) => {
   const browser = useBrowser();
-  const { setEditor, modifyEditor, getMonacoSelection } = useMonacoEditor({ scriptAreaDatatypeEditor: true });
+  const { setEditor, modifyEditor, getMonacoSelection, getSelectionRange } = useMonacoEditor();
   const path = usePath();
+  const keyActionMountFunc = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    editor.addCommand(monaco.KeyCode.F2, () => {
+      props.maximizeState.setIsMaximizedCodeEditorOpen(true);
+    });
+  };
 
   return props.maximizeState.isMaximizedCodeEditorOpen ? (
     <MaximizedCodeEditorBrowser
@@ -26,10 +32,11 @@ const ScriptArea = (props: ScriptAreaProps) => {
       editorValue={props.value}
       location={path}
       applyEditor={props.onChange}
+      selectionRange={getSelectionRange()}
     />
   ) : (
     <div className='script-area'>
-      <ResizableCodeEditor {...props} location={path} onMountFuncs={[setEditor]} />
+      <ResizableCodeEditor {...props} location={path} onMountFuncs={[setEditor, keyActionMountFunc]} />
       <Browser {...browser} types={props.browsers} accept={modifyEditor} location={path} initSearchFilter={getMonacoSelection} />
     </div>
   );

--- a/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
+++ b/packages/editor/src/components/widgets/code-editor/useCodeEditor.ts
@@ -13,7 +13,7 @@ export const monacoAutoFocus = (editor: monaco.editor.IStandaloneCodeEditor) => 
 
 export type ModifyAction = (value: string) => string;
 
-export const useMonacoEditor = (options?: { modifyAction?: ModifyAction; scriptAreaDatatypeEditor?: boolean }) => {
+export const useMonacoEditor = (options?: { modifyAction?: ModifyAction }) => {
   const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor>();
 
   const modifyEditor = (value: BrowserValue, type: BrowserType) => {
@@ -63,6 +63,20 @@ export const useMonacoEditor = (options?: { modifyAction?: ModifyAction; scriptA
     }
   };
 
+  const getSelectionRange = (): monaco.IRange | null => {
+    const selection = editor?.getSelection();
+    if (selection) {
+      return {
+        startLineNumber: selection.startLineNumber,
+        startColumn: selection.startColumn,
+        endLineNumber: selection.endLineNumber,
+        endColumn: selection.endColumn
+      };
+    } else {
+      return null;
+    }
+  };
+
   const getMonacoSelection: () => string = () => {
     const selection = editor?.getSelection();
     if (selection) {
@@ -71,5 +85,5 @@ export const useMonacoEditor = (options?: { modifyAction?: ModifyAction; scriptA
     return '';
   };
 
-  return { setEditor, modifyEditor, getMonacoSelection };
+  return { setEditor, modifyEditor, getMonacoSelection, getSelectionRange };
 };


### PR DESCRIPTION
I have now implemented two features to the maximized code editor:
The maximized code editor can now be opened using the "F2" key.
The cursor position or selection from the minimized code editor is also transferred to the maximized code editor. Unfortunately, what doesn't work as well now is directly closing the browser again with the "Esc" key. To make this work, you have to first click outside the Monaco editor to lose focus and then it works.

What I have not implemented (yet) is transferring the cursor position and selection from the maximized code editor to the minimized code editor. However, I'm not sure if this is really necessary, as I don't expect someone to want to edit in the minimized editor immediately after working in the maximized code editor, especially right after clicking "apply." What do you think?

Lastly, I attempted to implement the entire "focusWithin" aspect in the ScriptArea similar to the ScriptInput. Unfortunately, the editor still behaves strangely when I click "apply" so i reverted these changes. I don't quite understand why but we can take a look at it together if you'd like. However, I now believe that it's not a bad idea to always have the Monaco Editor present, as otherwise, the cursor position and selection feature would no longer work or would become much more complicated to implement (I think).