### PR TITLE
XIVY-12550 Add Cms-Action to category path chooser

### DIFF
--- a/packages/editor/src/components/parts/common/info/Information.tsx
+++ b/packages/editor/src/components/parts/common/info/Information.tsx
@@ -1,7 +1,7 @@
 import type { DataUpdater } from '../../../../types/lambda';
 import { MacroArea, MacroInput, useFieldset } from '../../../../components/widgets';
 import { PathFieldset } from '../path/PathFieldset';
-import { useEditorContext, useMeta, usePath } from '../../../../context';
+import { useAction, useEditorContext, useMeta, usePath } from '../../../../context';
 import type { CategoryType } from '@axonivy/inscription-protocol';
 import { IvyIcons } from '@axonivy/editor-icons';
 import ClassificationCombobox, { type ClassifiedItem } from '../classification/ClassificationCombobox';
@@ -25,6 +25,7 @@ const Information = <T extends InformationConfig>({ config, update }: Informatio
 
   const { context } = useEditorContext();
   const path = usePath();
+  const openAction = useAction('openOrCreateCmsCategory');
 
   const type = (): CategoryType => {
     const location = path.toLowerCase();
@@ -64,7 +65,12 @@ const Information = <T extends InformationConfig>({ config, update }: Informatio
           {...descFieldset.inputProps}
         />
       </PathFieldset>
-      <PathFieldset label='Category' {...catFieldset.labelProps} path='category'>
+      <PathFieldset
+        label='Category'
+        {...catFieldset.labelProps}
+        path='category'
+        controls={[{ label: 'Open CMS Editor', icon: IvyIcons.Cms, action: () => openAction('/Categorie/' + config.category + '/name') }]}
+      >
         <ClassificationCombobox
           value={config.category}
           onChange={change => update('category', change)}

--- a/packages/protocol/src/data/inscription.ts
+++ b/packages/protocol/src/data/inscription.ts
@@ -58,13 +58,13 @@ export interface Inscription {
   restClientRequest: RestClientRequest;
   restContentTypeRequest: RestContentTypeRequest;
   restEntityInfoRequest: RestEntityInfoRequest;
-  restResource: RestResource;
+  restResource: RestResource[];
   restResourceRequest: RestResourceRequest;
-  roleMeta: RoleMeta[];
+  roleMeta: RoleMeta;
   schemaKey: SchemaKey;
   scriptingDataArgs: ScriptingDataArgs;
   signalCodeRequest: SignalCodeRequest;
-  string: string;
+  string: string[];
   typeSearchRequest: TypeSearchRequest;
   variableInfo: VariableInfo;
   void: Void;
@@ -274,6 +274,7 @@ export interface InscriptionActionArgs {
     | "openConfig"
     | "openCustomField"
     | "openEndPage"
+    | "openOrCreateCmsCategory"
     | "openPage"
     | "openProgram"
     | "openTestWs";


### PR DESCRIPTION
I have now integrated the new core action into the frontend. For this action, I used the CMS browser icon.

![grafik](https://github.com/axonivy/inscription-client/assets/141223521/74e526ea-d640-4896-be77-cf0187333e18)
