### PR TITLE
Imgbot ignores svg images

### DIFF
--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,0 +1,3 @@
+{
+  "ignoredFiles": ["*.svg"]
+}


### PR DESCRIPTION
This could be a way of disabling imgbot just for svg images. Generally the bot is enabled for all repositories on the axonivy organization at the moment ...