### PR TITLE
XIVY-13091: Fix search/insert bug for role browser

### DIFF
--- a/packages/editor/src/components/browser/role/RoleBrowser.tsx
+++ b/packages/editor/src/components/browser/role/RoleBrowser.tsx
@@ -97,6 +97,7 @@ const RoleBrowser = (props: {
           value: globalFilter,
           onChange: newFilterValue => {
             setGlobalFilter(newFilterValue);
+            setRowSelection({});
             setExpanded(true);
           }
         }}


### PR DESCRIPTION
I forgot to add this line of code, which resulted in the inscription crashing when something was first selected and then searched for something else in the search field. Now it works (this is already built into the other browsers).