### PR TITLE
XIVY-13253: Prevents display of error on new line in parameter table

### DIFF
--- a/packages/editor/src/components/parts/common/parameter/ParameterTable.test.tsx
+++ b/packages/editor/src/components/parts/common/parameter/ParameterTable.test.tsx
@@ -60,7 +60,7 @@ describe('ParameterTable', () => {
     expect(view.data()).toEqual([
       { name: 'field1', type: 'String', desc: 'this is a string' },
       { name: 'number', type: 'Number', desc: '1' },
-      { name: '', type: 'String', desc: '' }
+      { name: 'change_this_name', type: 'String', desc: '' }
     ]);
   });
 

--- a/packages/editor/src/components/parts/common/parameter/ParameterTable.tsx
+++ b/packages/editor/src/components/parts/common/parameter/ParameterTable.tsx
@@ -14,7 +14,7 @@ type ParameterTableProps = {
   hideDesc?: boolean;
 };
 
-const EMPTY_SCRIPT_VARIABLE: ScriptVariable = { name: '', type: 'String', desc: '' } as const;
+const EMPTY_SCRIPT_VARIABLE: ScriptVariable = { name: 'change_this_name', type: 'String', desc: '' } as const;
 
 const ParameterTable = ({ data, onChange, hideDesc, label }: ParameterTableProps) => {
   const columns = useMemo(() => {


### PR DESCRIPTION
To prevent errors when adding a new row to the parameter table, a default value is now added to the name. 

I've named it "change_this_name" to signal that the name needs to be changed. If the name isn't changed and the component is reloaded or the selection is lost, the new row will be removed from the table. I haven't named it "parameter" because I can imagine that this name might often be forgotten to be updated. 
What do you think?