### PR TITLE
Fix import of typebrowser and typo inside addCms action

### DIFF
--- a/integrations/standalone/tests/mock/browser/typeBrowser.spec.ts
+++ b/integrations/standalone/tests/mock/browser/typeBrowser.spec.ts
@@ -49,7 +49,7 @@ test.describe('Type browser', () => {
     await assertCodeVisible(page);
 
     await applyTypeBrowser(page, 0, 'ch.ivyteam.test.Person', true);
-    await expect(code(page).getByRole('textbox')).toHaveValue('java.util.List<ch.ivyteam.test.Person>');
+    await expect(code(page).getByRole('textbox')).toHaveValue('List<ch.ivyteam.test.Person>');
   });
 
   test('browser add type doubleclick', async ({ page }) => {
@@ -78,7 +78,7 @@ test.describe('Type browser', () => {
     } else {
       if (checkListGeneric) {
         await page.getByLabel('Use Type as List').click();
-        await expect(page.locator('.browser-helptext')).toHaveText('java.util.List<' + expectedSelection + '>');
+        await expect(page.locator('.browser-helptext')).toHaveText('List<' + expectedSelection + '>');
       } else {
         await expect(page.locator('.browser-helptext')).toHaveText(expectedSelection);
       }

--- a/packages/editor/src/components/browser/type/TypeBrowser.tsx
+++ b/packages/editor/src/components/browser/type/TypeBrowser.tsx
@@ -187,7 +187,7 @@ const TypeBrowser = ({ value, onChange, onDoubleClick, initSearchFilter, locatio
     if (location.includes('code')) {
       onChange({
         cursorValue: getCursorValue(selectedRow.original, isIvyType, typeAsList, true),
-        firstLineValue: isIvyType || typeAsList ? undefined : 'import ' + selectedRow.original.fullQualifiedName + ';\n'
+        firstLineValue: isIvyType ? undefined : 'import ' + selectedRow.original.fullQualifiedName + ';\n'
       });
     } else {
       onChange({

--- a/packages/editor/src/components/browser/type/cursor-value.test.ts
+++ b/packages/editor/src/components/browser/type/cursor-value.test.ts
@@ -15,7 +15,7 @@ test('getCursorValue handles IvyType and typeAsList and inCodeBlock', () => {
 });
 
 test('getCursorValue handles IvyType, typeAsList, and not inCodeBlock', () => {
-  expect(getCursorValue(value, true, true, false)).toEqual('java.util.List<SampleType>');
+  expect(getCursorValue(value, true, true, false)).toEqual('List<SampleType>');
 });
 
 test('getCursorValue handles IvyType, non-typeAsList, and inCodeBlock', () => {
@@ -23,11 +23,11 @@ test('getCursorValue handles IvyType, non-typeAsList, and inCodeBlock', () => {
 });
 
 test('getCursorValue handles no IvyType, typeAsList, and inCodeBlock', () => {
-  expect(getCursorValue(value, false, true, true)).toEqual('List<com.example.SampleType>');
+  expect(getCursorValue(value, false, true, true)).toEqual('List<SampleType>');
 });
 
-test('getCursorValue handles non-IvyType and non-typeAsList', () => {
-  expect(getCursorValue(value, false, false, true)).toEqual('com.example.SampleType');
+test('getCursorValue handles non-IvyType and non-typeAsList an inCodeBlock', () => {
+  expect(getCursorValue(value, false, false, true)).toEqual('SampleType');
 });
 
 test('getCursorValue handles IvyType, not-typeAsList, and not inCodeBlock', () => {
@@ -35,7 +35,7 @@ test('getCursorValue handles IvyType, not-typeAsList, and not inCodeBlock', () =
 });
 
 test('getCursorValue handles non-IvyType, typeAsList, and not inCodeBlock', () => {
-  expect(getCursorValue(value, false, true, false)).toEqual('java.util.List<com.example.SampleType>');
+  expect(getCursorValue(value, false, true, false)).toEqual('List<com.example.SampleType>');
 });
 
 test('getCursorValue handles non-IvyType and non-typeAsList and not inCodeBlock', () => {

--- a/packages/editor/src/components/browser/type/cursor-value.ts
+++ b/packages/editor/src/components/browser/type/cursor-value.ts
@@ -1,17 +1,9 @@
 import type { TypeBrowserObject } from './TypeBrowser';
 
-const addListGeneric = (value: string, inCodeBlock: boolean) => {
-  let listPrefix = 'java.util.List';
-  if (inCodeBlock) {
-    listPrefix = 'List';
-  }
-  return `${listPrefix}<${value}>`;
-};
-
 export const getCursorValue = (value: TypeBrowserObject, isIvyType: boolean, typeAsList: boolean, inCodeBlock: boolean) => {
-  if (isIvyType) {
-    return typeAsList ? addListGeneric(value.simpleName, inCodeBlock) : value.simpleName;
+  if (isIvyType || inCodeBlock) {
+    return typeAsList ? 'List<' + value.simpleName + '>' : value.simpleName;
   } else {
-    return typeAsList ? addListGeneric(value.fullQualifiedName, inCodeBlock) : value.fullQualifiedName;
+    return typeAsList ? 'List<' + value.fullQualifiedName + '>' : value.fullQualifiedName;
   }
 };

--- a/packages/editor/src/components/parts/common/info/Information.tsx
+++ b/packages/editor/src/components/parts/common/info/Information.tsx
@@ -70,7 +70,7 @@ const Information = <T extends InformationConfig>({ config, update }: Informatio
         label='Category'
         {...catFieldset.labelProps}
         path='category'
-        controls={[{ label: 'Open CMS Editor', icon: IvyIcons.Cms, action: () => openAction('/Categorie/' + config.category + '/name') }]}
+        controls={[{ label: 'Open CMS Editor', icon: IvyIcons.Cms, action: () => openAction('/Categories/' + config.category + '/name') }]}
       >
         <ClassificationCombobox
           value={config.category}


### PR DESCRIPTION
I have fixed a typo within the addCMS-Action for the Category-Field and also improved the import behavior of the type browser for the code block. It now behaves as follows:

Type browser opened within the code block:
**Import IvyType:** No "import ...", only the simple name of the IvyType is added.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/774f81dd-6771-47ac-8244-0d6d9bd9ce17)
**Import nonIvyType:** First line: import fullQualifiedName of Type, then only the simple name of the Type is added.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/913ba994-e07e-4ef7-980b-2e103e5c61fb)
**Import IvyType as List:** No "import ...", only List<simple name of the IvyType> is added.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/715bb35d-b84d-4945-9c19-c3754c7f498e)
**Import nonIvyType as List:** First "import fullQualifiedName of Type", then List<simple name of the Types> is added.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/e34f9191-96db-427c-b104-0ce8cf0daaf3)

Type browser not opened within a code block (the "import ..." line is always completely omitted):
**Import IvyType:** Only the simple name of the IvyType is added.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/43e21a0e-18f0-43cf-801b-db759299c997)
**Import nonIvyType:** The fullQualifiedName of the Type is added.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/c1c6683b-15a0-4a4e-ae26-b59047b813ac)
**Import IvyType as List:** Only fullQualifiedName of the List and simple name of the IvyType are added, hence java.util.List<simple name of the IvyType>.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/9db1bcbf-1471-459c-a29a-2a6610b7897c)
**Import nonIvyType as List:** Only fullQualifiedName of the List and fullQualifiedName of the Type are added, hence java.util.List<fullQualifiedName of the IvyType>.
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/ae0c26d4-f5b3-44c3-bcd4-2e27123e9e23)