### PR TITLE
XIVY-11709: First version of thirdparty-editors

### DIFF
--- a/integrations/standalone/tests/integration/activites/interface/rule.spec.ts
+++ b/integrations/standalone/tests/integration/activites/interface/rule.spec.ts
@@ -1,7 +1,9 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
+import { GeneralTest, runTest } from '../../parts';
 import { InscriptionView } from '../../../pageobjects/InscriptionView';
-import type { CreateProcessResult} from '../../../glsp-protocol';
+import type { CreateProcessResult } from '../../../glsp-protocol';
 import { createProcess } from '../../../glsp-protocol';
+import { RuleInterfaceStartTest } from '../../parts/program-interface-start';
 
 test.describe('Rule', () => {
   let view: InscriptionView;
@@ -16,6 +18,14 @@ test.describe('Rule', () => {
   });
 
   test('Header', async () => {
-    await expect(view.page.locator('.no-editor')).toHaveText('No Editor found for type: ThirdPartyProgramInterface');
+    await view.expectHeaderText('Rule');
+  });
+
+  test('General', async () => {
+    await runTest(view, GeneralTest);
+  });
+
+  test('Start', async () => {
+    await runTest(view, RuleInterfaceStartTest);
   });
 });

--- a/integrations/standalone/tests/integration/parts/program-interface-start.ts
+++ b/integrations/standalone/tests/integration/parts/program-interface-start.ts
@@ -62,4 +62,54 @@ class ProgramInterfaceStart extends PartObject {
   }
 }
 
+class RuleInterfaceStart extends PartObject {
+  programSection: Section;
+  errorProgram: Select;
+
+  timeoutSection: Section;
+  seconds: ScriptInput;
+  errorTimeout: Select;
+
+  constructor(part: Part) {
+    super(part);
+    this.programSection = part.section('Program');
+    this.errorProgram = this.programSection.select('Error');
+
+    this.timeoutSection = part.section('Timeout');
+    this.seconds = this.timeoutSection.scriptInput('Seconds');
+    this.errorTimeout = this.timeoutSection.select('Error');
+  }
+
+  async fill() {
+    await this.programSection.toggle();
+    await this.errorProgram.choose('>> Ignore Exception');
+
+    await this.timeoutSection.toggle();
+    await this.seconds.fill('3');
+    await this.errorTimeout.choose('>> Ignore Exception');
+  }
+
+  async assertFill() {
+    await this.programSection.expectIsOpen();
+    await this.errorProgram.expectValue('>> Ignore Exception');
+
+    await this.timeoutSection.expectIsOpen();
+    await this.seconds.expectValue('3');
+    await this.errorTimeout.expectValue('>> Ignore Exception');
+  }
+
+  async clear() {
+    await this.errorProgram.choose('ivy:error:program:exception');
+
+    await this.seconds.fill('0');
+    await this.errorTimeout.choose('ivy:error:program:timeout');
+  }
+
+  async assertClear() {
+    await this.programSection.expectIsClosed();
+    await this.timeoutSection.expectIsClosed();
+  }
+}
+
 export const ProgramInterfaceStartTest = new NewPartTest('Start', (part: Part) => new ProgramInterfaceStart(part));
+export const RuleInterfaceStartTest = new NewPartTest('Start', (part: Part) => new RuleInterfaceStart(part));

--- a/packages/editor/src/components/editors/InscriptionEditor.tsx
+++ b/packages/editor/src/components/editors/InscriptionEditor.tsx
@@ -13,8 +13,15 @@ import { useGeneralData } from '../parts/name/useGeneralData';
 import Part from './part/Part';
 import type { PartProps } from './part/usePart';
 import { otherEditors } from './other-editors';
+import { thirdPartyEditors } from './third-party/all-third-party-editors';
 
-const editors = new Map<ElementType, ReactNode>([...eventEditors, ...gatewayEditors, ...activityEditors, ...otherEditors]);
+const editors = new Map<ElementType, ReactNode>([
+  ...eventEditors,
+  ...gatewayEditors,
+  ...activityEditors,
+  ...thirdPartyEditors,
+  ...otherEditors
+]);
 
 export const inscriptionEditor = (type?: ElementType): ReactNode => {
   if (type) {

--- a/packages/editor/src/components/editors/third-party/all-third-party-editors.tsx
+++ b/packages/editor/src/components/editors/third-party/all-third-party-editors.tsx
@@ -1,0 +1,11 @@
+import type { ElementType } from '@axonivy/inscription-protocol';
+import { thirdPartyInterfaceActivityEditors } from './interface';
+import type { ReactNode } from 'react';
+import { thirdPartyStartEventEditors } from './start';
+import { thirdPartyIntermediateEventEditors } from './intermediate';
+
+export const thirdPartyEditors = new Map<ElementType, ReactNode>([
+  ...thirdPartyInterfaceActivityEditors,
+  ...thirdPartyStartEventEditors,
+  ...thirdPartyIntermediateEventEditors
+]);

--- a/packages/editor/src/components/editors/third-party/interface.tsx
+++ b/packages/editor/src/components/editors/third-party/interface.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/jsx-key */
+import { IvyIcons } from '@axonivy/ui-icons';
+import type { ElementType } from '@axonivy/inscription-protocol';
+import type { ReactNode } from 'react';
+import { memo } from 'react';
+import InscriptionEditor from '../InscriptionEditor';
+import { useGeneralPart, useProgramInterfaceStartPart, useConfigurationPart } from '../../../components/parts';
+
+const ThirdPartyProgramInterfaceEditor = memo(() => {
+  const name = useGeneralPart();
+  const start = useProgramInterfaceStartPart({ thirdParty: true });
+  const configuration = useConfigurationPart();
+  return <InscriptionEditor icon={IvyIcons.Extension} parts={[name, start, configuration]} />;
+});
+
+export const thirdPartyInterfaceActivityEditors = new Map<ElementType, ReactNode>([
+  ['ThirdPartyProgramInterface', <ThirdPartyProgramInterfaceEditor />]
+]);

--- a/packages/editor/src/components/editors/third-party/intermediate.tsx
+++ b/packages/editor/src/components/editors/third-party/intermediate.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/jsx-key */
+import { IvyIcons } from '@axonivy/ui-icons';
+import type { ElementType } from '@axonivy/inscription-protocol';
+import type { ReactNode } from 'react';
+import { memo } from 'react';
+import InscriptionEditor from '../InscriptionEditor';
+import { useConfigurationPart, useEventPart, useGeneralPart, useOutputPart, useTaskPart } from '../../../components/parts';
+
+const ThirdPartyWaitEventEditor = memo(() => {
+  const name = useGeneralPart();
+  const event = useEventPart({ thirdParty: true });
+  const configuration = useConfigurationPart();
+  const task = useTaskPart({ type: 'wait' });
+  const output = useOutputPart();
+  return <InscriptionEditor icon={IvyIcons.Extension} parts={[name, event, configuration, task, output]} />;
+});
+
+export const thirdPartyIntermediateEventEditors = new Map<ElementType, ReactNode>([['ThirdPartyWaitEvent', <ThirdPartyWaitEventEditor />]]);

--- a/packages/editor/src/components/editors/third-party/start.tsx
+++ b/packages/editor/src/components/editors/third-party/start.tsx
@@ -1,0 +1,17 @@
+/* eslint-disable react/jsx-key */
+import { IvyIcons } from '@axonivy/ui-icons';
+import type { ElementType } from '@axonivy/inscription-protocol';
+import type { ReactNode } from 'react';
+import { memo } from 'react';
+import InscriptionEditor from '../InscriptionEditor';
+
+import { useGeneralPart, useProgramStartPart, useConfigurationPart } from '../../../components/parts';
+
+const ThirdPartyProgramStartEditor = memo(() => {
+  const name = useGeneralPart();
+  const start = useProgramStartPart({ thirdParty: true });
+  const configuration = useConfigurationPart();
+  return <InscriptionEditor icon={IvyIcons.Extension} parts={[name, start, configuration]} />;
+});
+
+export const thirdPartyStartEventEditors = new Map<ElementType, ReactNode>([['ThirdPartyProgramStart', <ThirdPartyProgramStartEditor />]]);

--- a/packages/editor/src/components/parts/program/activity/ProgramInterfaceStartPart.tsx
+++ b/packages/editor/src/components/parts/program/activity/ProgramInterfaceStartPart.tsx
@@ -9,7 +9,7 @@ import { useValidations } from '../../../../context';
 import { deepEqual } from '../../../../utils/equals';
 import JavaClassSelector from '../JavaClassSelector';
 
-export function useProgramInterfaceStartPart(): PartProps {
+export function useProgramInterfaceStartPart(options?: { thirdParty?: boolean }): PartProps {
   const { config, defaultConfig, initConfig, reset } = useProgramInterfaceStartData();
   const compareData = (data: ProgramInterfaceStartData) => [data.javaClass, data.exceptionHandler, data.timeout];
   const validation = [...useValidations(['timeout']), ...useValidations(['exceptionHandler']), ...useValidations(['javaClass'])];
@@ -19,11 +19,11 @@ export function useProgramInterfaceStartPart(): PartProps {
     name: 'Start',
     state,
     reset: { dirty, action: () => reset() },
-    content: <ProgramInterfaceStartPart />
+    content: <ProgramInterfaceStartPart thirdParty={options?.thirdParty} />
   };
 }
 
-const ProgramInterfaceStartPart = () => {
+const ProgramInterfaceStartPart = ({ thirdParty }: { thirdParty?: boolean }) => {
   const { config, defaultConfig, update, updateTimeout } = useProgramInterfaceStartData();
 
   const errorFieldset = useFieldset();
@@ -32,7 +32,9 @@ const ProgramInterfaceStartPart = () => {
 
   return (
     <>
-      <JavaClassSelector javaClass={config.javaClass} onChange={change => update('javaClass', change)} type='ACTIVITY' />
+      {(thirdParty === undefined || thirdParty === false) && (
+        <JavaClassSelector javaClass={config.javaClass} onChange={change => update('javaClass', change)} type='ACTIVITY' />
+      )}
 
       <PathCollapsible label='Program' path='exceptionHandler' defaultOpen={config.exceptionHandler !== defaultConfig.exceptionHandler}>
         <PathFieldset label='Error' path='error' {...errorFieldset.labelProps}>

--- a/packages/editor/src/components/parts/program/event/ProgramStartPart.tsx
+++ b/packages/editor/src/components/parts/program/event/ProgramStartPart.tsx
@@ -1,12 +1,12 @@
 import type { ProgramStartData } from '@axonivy/inscription-protocol';
-import type { PartProps} from '../../../editors';
+import type { PartProps } from '../../../editors';
 import { usePartDirty, usePartState } from '../../../editors';
 import { useValidations } from '../../../../context';
 import { useProgramStartData } from './useProgramStartData';
 import { Permission } from '../../common/permission/Permission';
 import JavaClassSelector from '../JavaClassSelector';
 
-export function useProgramStartPart(): PartProps {
+export function useProgramStartPart(options?: { thirdParty?: boolean }): PartProps {
   const { config, defaultConfig, initConfig, reset } = useProgramStartData();
   const compareData = (data: ProgramStartData) => [data.javaClass, data.permission];
   const validation = useValidations(['javaClass']);
@@ -16,16 +16,19 @@ export function useProgramStartPart(): PartProps {
     name: 'Start',
     state,
     reset: { dirty, action: () => reset() },
-    content: <ProgramStartPart />
+    content: <ProgramStartPart thirdParty={options?.thirdParty} />
   };
 }
 
-const ProgramStartPart = () => {
+const ProgramStartPart = ({ thirdParty }: { thirdParty?: boolean }) => {
   const { config, defaultConfig, update, updatePermission } = useProgramStartData();
 
   return (
     <>
-      <JavaClassSelector javaClass={config.javaClass} onChange={change => update('javaClass', change)} type='START' />
+      {(thirdParty === undefined || thirdParty === false) && (
+        <JavaClassSelector javaClass={config.javaClass} onChange={change => update('javaClass', change)} type='START' />
+      )}
+
       <Permission
         anonymousFieldActive={true}
         config={config.permission}

--- a/packages/editor/src/components/parts/program/intermediate/EventPart.tsx
+++ b/packages/editor/src/components/parts/program/intermediate/EventPart.tsx
@@ -9,7 +9,7 @@ import { useEventData } from './useEventData';
 import JavaClassSelector from '../JavaClassSelector';
 import { deepEqual } from '../../../../utils/equals';
 
-export function useEventPart(): PartProps {
+export function useEventPart(options?: { thirdParty?: boolean }): PartProps {
   const { config, defaultConfig, initConfig, reset } = useEventData();
   const compareData = (data: EventData) => [data.javaClass, data.eventId, data.timeout];
   const validation = [...useValidations(['timeout']), ...useValidations(['eventId']), ...useValidations(['javaClass'])];
@@ -19,11 +19,11 @@ export function useEventPart(): PartProps {
     name: 'Event',
     state,
     reset: { dirty, action: () => reset() },
-    content: <EventPart />
+    content: <EventPart thirdParty={options?.thirdParty} />
   };
 }
 
-const EventPart = () => {
+const EventPart = ({ thirdParty }: { thirdParty?: boolean }) => {
   const { config, defaultConfig, update, updateTimeout } = useEventData();
 
   const eventIdFieldset = useFieldset();
@@ -33,7 +33,9 @@ const EventPart = () => {
 
   return (
     <>
-      <JavaClassSelector javaClass={config.javaClass} onChange={change => update('javaClass', change)} type='INTERMEDIATE' />
+      {(thirdParty === undefined || thirdParty === false) && (
+        <JavaClassSelector javaClass={config.javaClass} onChange={change => update('javaClass', change)} type='INTERMEDIATE' />
+      )}
 
       <PathFieldset label='Event ID' path='eventId' {...eventIdFieldset.labelProps}>
         <ScriptInput


### PR DESCRIPTION
I have now added the three third-party editors (Rule, Intermediate-ThridPartyWait, Start-ThirdPartyStart). I have removed the Java class selector from both the Start and Event tabs for thirdparty-editors.

@ivy-lli  I have created a new folder "third-party" where I have placed all the thirdparty-editors. There are actually only three editors, which I could also simply incorporate into the "other-editors" TSX file. What do you think?

![beispiel_thirdParty](https://github.com/axonivy/inscription-client/assets/141223521/184c9c09-7d2f-4791-9d31-797798cebf03)
