### PR TITLE
XIVY-13508: Add placeholder to monaco-editor

### DIFF
--- a/packages/editor/src/components/parts/condition/ConditionTable.tsx
+++ b/packages/editor/src/components/parts/condition/ConditionTable.tsx
@@ -44,7 +44,7 @@ const ConditionTable = ({ data, onChange }: { data: Condition[]; onChange: (chan
         header: header => <TextHeader header={header} name='Expression' />,
         cell: cell => (
           <ReorderWrapperIcon>
-            <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.BOOLEAN} browsers={['attr', 'func', 'type']} />
+            <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.BOOLEAN} browsers={['attr', 'func', 'type']} placeholder='Enter an Expression' />
           </ReorderWrapperIcon>
         )
       }

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.css
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.css
@@ -14,3 +14,16 @@
 .code-editor .code-input:focus-within {
   border: var(--activ-border);
 }
+
+.code-editor .monaco-placeholder {
+  position: absolute;
+  display: none;
+  white-space: pre-wrap;
+  top: 12px;
+  left: 11px;
+  color: var(--N500);
+  font-family: Consolas, 'Courier New', monospace;
+  pointer-events: none;
+  user-select: none;
+  z-index: 10;
+}

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.css
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.css
@@ -25,5 +25,10 @@
   font-family: Consolas, 'Courier New', monospace;
   pointer-events: none;
   user-select: none;
-  z-index: 10;
+  z-index: 2;
+}
+
+.code-editor .with-lineNumbers {
+  left: 35px;
+  font-size: 12px;
 }

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
@@ -11,12 +11,11 @@ export type CodeEditorProps = {
   context: { location: string; type?: string };
   macro?: boolean;
   height?: number;
-  placeholder?: string;
   onMountFuncs?: Array<(editor: monaco.editor.IStandaloneCodeEditor) => void>;
   options?: monaco.editor.IStandaloneEditorConstructionOptions;
 };
 
-const CodeEditor = ({ value, onChange, placeholder, context, macro, onMountFuncs, options, ...props }: CodeEditorProps) => {
+const CodeEditor = ({ value, onChange, context, macro, onMountFuncs, options, ...props }: CodeEditorProps) => {
   const { elementContext, readonly } = useEditorContext();
   const placeholderElement = useRef<HTMLDivElement>(null);
   const handlePlaceholder = (showPlaceholder: boolean) => {
@@ -57,11 +56,10 @@ const CodeEditor = ({ value, onChange, placeholder, context, macro, onMountFuncs
         onMount={handleEditorDidMount}
         {...props}
       />
-      {placeholder && (
-        <div ref={placeholderElement} className='monaco-placeholder'>
-          {placeholder}
-        </div>
-      )}
+
+      <div ref={placeholderElement} className={`monaco-placeholder ${monacoOptions.lineNumbers === 'on' ? 'with-lineNumbers' : ''}`}>
+        Press CTRL + SPACE for auto-completion
+      </div>
     </div>
   );
 };

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.tsx
@@ -3,6 +3,7 @@ import { Editor } from '@monaco-editor/react';
 import { useEditorContext } from '../../../context';
 import { MONACO_OPTIONS, MonacoEditorUtil } from '../../../monaco/monaco-editor-util';
 import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import { useRef } from 'react';
 
 export type CodeEditorProps = {
   value: string;
@@ -10,15 +11,27 @@ export type CodeEditorProps = {
   context: { location: string; type?: string };
   macro?: boolean;
   height?: number;
+  placeholder?: string;
   onMountFuncs?: Array<(editor: monaco.editor.IStandaloneCodeEditor) => void>;
   options?: monaco.editor.IStandaloneEditorConstructionOptions;
 };
 
-const CodeEditor = ({ value, onChange, context, macro, onMountFuncs, options, ...props }: CodeEditorProps) => {
+const CodeEditor = ({ value, onChange, placeholder, context, macro, onMountFuncs, options, ...props }: CodeEditorProps) => {
   const { elementContext, readonly } = useEditorContext();
+  const placeholderElement = useRef<HTMLDivElement>(null);
+  const handlePlaceholder = (showPlaceholder: boolean) => {
+    if (placeholderElement.current) {
+      if (showPlaceholder) {
+        placeholderElement!.current.style.display = 'block';
+      } else {
+        placeholderElement!.current.style.display = 'none';
+      }
+    }
+  };
 
   const handleEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
     onMountFuncs?.forEach(func => func(editor));
+    handlePlaceholder(editor.getValue() === '');
   };
 
   const monacoOptions = options ?? MONACO_OPTIONS;
@@ -37,10 +50,18 @@ const CodeEditor = ({ value, onChange, context, macro, onMountFuncs, options, ..
         defaultPath={`${language}/${contextPath}/${context.location}/${context.type ? context.type : ''}`}
         options={monacoOptions}
         theme={MonacoEditorUtil.DEFAULT_THEME_NAME}
-        onChange={code => onChange(code ?? '')}
+        onChange={code => {
+          handlePlaceholder(!code);
+          onChange(code ?? '');
+        }}
         onMount={handleEditorDidMount}
         {...props}
       />
+      {placeholder && (
+        <div ref={placeholderElement} className='monaco-placeholder'>
+          {placeholder}
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
@@ -10,6 +10,7 @@ type EditorOptions = {
   editorOptions?: {
     fixedOverflowWidgets?: boolean;
   };
+  placeholder?: string;
   keyActions?: {
     enter?: () => void;
     tab?: () => void;
@@ -21,8 +22,16 @@ type EditorOptions = {
 export type CodeEditorInputProps = Omit<CodeEditorProps, 'macro' | 'options' | 'onMount' | 'height' | 'onMountFuncs' | 'context'> &
   EditorOptions & { browsers: BrowserType[] };
 
-const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, keyActions, ...props }: CodeEditorProps & EditorOptions) => {
+const SingleLineCodeEditor = ({
+  onChange,
+  onMountFuncs,
+  editorOptions,
+  keyActions,
+  placeholder,
+  ...props
+}: CodeEditorProps & EditorOptions) => {
   const mountFuncs = onMountFuncs ? onMountFuncs : [];
+
   const singleLineMountFuncs = (editor: monaco.editor.IStandaloneCodeEditor) => {
     editor.createContextKey('singleLine', true);
     const isSuggestWidgetOpen = (editor: monaco.editor.IStandaloneCodeEditor) =>
@@ -31,6 +40,7 @@ const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, keyAction
     const triggerAcceptSuggestion = (editor: monaco.editor.IStandaloneCodeEditor) =>
       editor.trigger(undefined, 'acceptSelectedSuggestion', undefined);
     const STATE_OPEN = 3;
+
     editor.addCommand(
       monaco.KeyCode.Enter,
       () => {
@@ -81,6 +91,7 @@ const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, keyAction
     <CodeEditor
       height={40}
       onChange={onCodeChange}
+      placeholder={placeholder}
       options={editorOptions ? { ...SINGLE_LINE_MONACO_OPTIONS, ...editorOptions } : SINGLE_LINE_MONACO_OPTIONS}
       onMountFuncs={[...mountFuncs, monacoAutoFocus, singleLineMountFuncs]}
       {...props}

--- a/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
@@ -10,7 +10,6 @@ type EditorOptions = {
   editorOptions?: {
     fixedOverflowWidgets?: boolean;
   };
-  placeholder?: string;
   keyActions?: {
     enter?: () => void;
     tab?: () => void;
@@ -22,14 +21,7 @@ type EditorOptions = {
 export type CodeEditorInputProps = Omit<CodeEditorProps, 'macro' | 'options' | 'onMount' | 'height' | 'onMountFuncs' | 'context'> &
   EditorOptions & { browsers: BrowserType[] };
 
-const SingleLineCodeEditor = ({
-  onChange,
-  onMountFuncs,
-  editorOptions,
-  keyActions,
-  placeholder,
-  ...props
-}: CodeEditorProps & EditorOptions) => {
+const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, keyActions, ...props }: CodeEditorProps & EditorOptions) => {
   const mountFuncs = onMountFuncs ? onMountFuncs : [];
 
   const singleLineMountFuncs = (editor: monaco.editor.IStandaloneCodeEditor) => {
@@ -91,7 +83,6 @@ const SingleLineCodeEditor = ({
     <CodeEditor
       height={40}
       onChange={onCodeChange}
-      placeholder={placeholder}
       options={editorOptions ? { ...SINGLE_LINE_MONACO_OPTIONS, ...editorOptions } : SINGLE_LINE_MONACO_OPTIONS}
       onMountFuncs={[...mountFuncs, monacoAutoFocus, singleLineMountFuncs]}
       {...props}

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -87,7 +87,6 @@ export function CodeEditorCell<TData>({ cell, makro, type, browsers, placeholder
                     context={{ type, location: path }}
                     onMountFuncs={[setEditor]}
                     editorOptions={{ fixedOverflowWidgets: false }}
-                    placeholder='Press CTRL + SPACE for auto-completion'
                     keyActions={{
                       enter: () => closeRef.current?.click(),
                       escape: () => closeRef.current?.click(),

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -87,6 +87,7 @@ export function CodeEditorCell<TData>({ cell, makro, type, browsers, placeholder
                     context={{ type, location: path }}
                     onMountFuncs={[setEditor]}
                     editorOptions={{ fixedOverflowWidgets: false }}
+                    placeholder='Press CTRL + SPACE for auto-completion'
                     keyActions={{
                       enter: () => closeRef.current?.click(),
                       escape: () => closeRef.current?.click(),


### PR DESCRIPTION
I have implemented the option to add a placeholder to the Monaco editor. Currently, I have structured it so that the placeholder text can be passed into the CodeEditor as a parameter. At the moment, the placeholder "Press CTRL + SPACE for auto-completion" is simply present in all CodeEditorCells. However, it might make sense to set this placeholder for all singleLineCodeEditors or even for all Monaco editors. What do you think?
![beispiel_placeholder](https://github.com/axonivy/inscription-client/assets/141223521/f2e4b0d5-3921-4945-bb8f-c4d3af378c3d)
