### PR TITLE
XIVY-11709: Remove third-party-icon and fix placeholder

### DIFF
--- a/packages/editor/src/components/editors/InscriptionEditor.tsx
+++ b/packages/editor/src/components/editors/InscriptionEditor.tsx
@@ -31,7 +31,7 @@ export const inscriptionEditor = (type?: ElementType): ReactNode => {
 };
 
 export interface EditorProps {
-  icon: IvyIcons;
+  icon?: IvyIcons;
   parts: PartProps[];
 }
 
@@ -45,7 +45,7 @@ const Header = (props: EditorProps) => {
     <>
       <div className='header'>
         <div className='header-left'>
-          <IvyIcon icon={props.icon} />
+          {props.icon && <IvyIcon icon={props.icon} />}
           <div className='header-title'>
             {editorContext.type.shortLabel}
             {data.name.length > 0 && ` - ${data.name}`}

--- a/packages/editor/src/components/editors/third-party/interface.tsx
+++ b/packages/editor/src/components/editors/third-party/interface.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-key */
-import { IvyIcons } from '@axonivy/ui-icons';
 import type { ElementType } from '@axonivy/inscription-protocol';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
@@ -10,7 +9,7 @@ const ThirdPartyProgramInterfaceEditor = memo(() => {
   const name = useGeneralPart();
   const start = useProgramInterfaceStartPart({ thirdParty: true });
   const configuration = useConfigurationPart();
-  return <InscriptionEditor icon={IvyIcons.Extension} parts={[name, start, configuration]} />;
+  return <InscriptionEditor parts={[name, start, configuration]} />;
 });
 
 export const thirdPartyInterfaceActivityEditors = new Map<ElementType, ReactNode>([

--- a/packages/editor/src/components/editors/third-party/intermediate.tsx
+++ b/packages/editor/src/components/editors/third-party/intermediate.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-key */
-import { IvyIcons } from '@axonivy/ui-icons';
 import type { ElementType } from '@axonivy/inscription-protocol';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
@@ -12,7 +11,7 @@ const ThirdPartyWaitEventEditor = memo(() => {
   const configuration = useConfigurationPart();
   const task = useTaskPart({ type: 'wait' });
   const output = useOutputPart();
-  return <InscriptionEditor icon={IvyIcons.Extension} parts={[name, event, configuration, task, output]} />;
+  return <InscriptionEditor parts={[name, event, configuration, task, output]} />;
 });
 
 export const thirdPartyIntermediateEventEditors = new Map<ElementType, ReactNode>([['ThirdPartyWaitEvent', <ThirdPartyWaitEventEditor />]]);

--- a/packages/editor/src/components/editors/third-party/start.tsx
+++ b/packages/editor/src/components/editors/third-party/start.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-key */
-import { IvyIcons } from '@axonivy/ui-icons';
 import type { ElementType } from '@axonivy/inscription-protocol';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
@@ -11,7 +10,7 @@ const ThirdPartyProgramStartEditor = memo(() => {
   const name = useGeneralPart();
   const start = useProgramStartPart({ thirdParty: true });
   const configuration = useConfigurationPart();
-  return <InscriptionEditor icon={IvyIcons.Extension} parts={[name, start, configuration]} />;
+  return <InscriptionEditor parts={[name, start, configuration]} />;
 });
 
 export const thirdPartyStartEventEditors = new Map<ElementType, ReactNode>([['ThirdPartyProgramStart', <ThirdPartyProgramStartEditor />]]);

--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.css
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.css
@@ -26,7 +26,6 @@
   font-family: Consolas, 'Courier New', monospace;
   pointer-events: none;
   user-select: none;
-  z-index: 2;
 }
 
 .code-editor .with-lineNumbers {


### PR DESCRIPTION
As discussed earlier, I have removed the icons from the third-party elements. Additionally, I made a small adjustment regarding the placeholder in the Monaco editor, which previously had an unpleasant overlaying effect.