### PR TITLE
XIVY-13506: Fix overflow of header inside autocompletion-details

### DIFF
--- a/packages/editor/src/components/widgets/code-editor/CodeEditor.css
+++ b/packages/editor/src/components/widgets/code-editor/CodeEditor.css
@@ -31,3 +31,7 @@
 .code-editor .with-lineNumbers {
   left: 35px;
 }
+
+.code-editor .header .type {
+  height: 100%;
+}


### PR DESCRIPTION
With this small fix, I can prevent the header text from overlapping other elements. Unfortunately, I don't really have the energy today to  figure out, how to send a shorter type for the header in the core. If you still wish to have the whole thing fixed in the core, I would create a follow-up story and address it after my vacation.