### PR TITLE
XIVY-13806: Add improvement from feedback

### DIFF
--- a/integrations/standalone/tests/integration/activites/interface/email.spec.ts
+++ b/integrations/standalone/tests/integration/activites/interface/email.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { InscriptionView } from '../../../pageobjects/InscriptionView';
-import { MailAttachmentTest, MailContentTest, MailHeaderTest, GeneralTest, runTest } from '../../parts';
+import { MailAttachmentTest, MailContentTest, MailHeaderTest, MailErrorTest, GeneralTest, runTest } from '../../parts';
 import type { CreateProcessResult } from '../../../glsp-protocol';
 import { createProcess } from '../../../glsp-protocol';
 
@@ -26,6 +26,10 @@ test.describe('EMail', () => {
 
   test('MailHeader', async () => {
     await runTest(view, MailHeaderTest);
+  });
+
+  test('MailError', async () => {
+    await runTest(view, MailErrorTest);
   });
 
   test('MailContent', async () => {

--- a/integrations/standalone/tests/integration/activites/interface/restclient.spec.ts
+++ b/integrations/standalone/tests/integration/activites/interface/restclient.spec.ts
@@ -58,7 +58,7 @@ test.describe('Rest Client', () => {
     await runTest(view, RestErrorTest);
   });
 
-  test('Output Data', async () => {
+  test('Output', async () => {
     await runTest(view, RestOutputTest);
   });
 });

--- a/integrations/standalone/tests/integration/activites/interface/webservice.spec.ts
+++ b/integrations/standalone/tests/integration/activites/interface/webservice.spec.ts
@@ -37,7 +37,7 @@ test.describe('Web Service', () => {
     await runTest(view, WsErrorTest);
   });
 
-  test('Output Data', async () => {
+  test('Output', async () => {
     await runTest(view, WsOutputTest);
   });
 });

--- a/integrations/standalone/tests/integration/parts/index.ts
+++ b/integrations/standalone/tests/integration/parts/index.ts
@@ -9,6 +9,7 @@ export * from './error-throw';
 export * from './mail-attachments';
 export * from './mail-content';
 export * from './mail-header';
+export * from './mail-error';
 export * from './name';
 export * from './output';
 export * from './request';

--- a/integrations/standalone/tests/integration/parts/mail-error.ts
+++ b/integrations/standalone/tests/integration/parts/mail-error.ts
@@ -1,0 +1,38 @@
+import type { Checkbox } from '../../pageobjects/Checkbox';
+import type { Part } from '../../pageobjects/Part';
+import type { Section } from '../../pageobjects/Section';
+import type { Select } from '../../pageobjects/Select';
+import { NewPartTest, PartObject } from './part-tester';
+
+class MailError extends PartObject {
+  error: Section;
+  errorSelect: Select;
+  throw: Checkbox;
+
+  constructor(part: Part) {
+    super(part);
+    this.error = part.section('Error');
+    this.errorSelect = this.error.select({});
+    this.throw = this.error.checkbox('Throw');
+  }
+
+  async fill() {
+    await this.error.toggle();
+    await this.errorSelect.choose('>> Ignore Exception');
+    await this.throw.click();
+  }
+  async assertFill() {
+    await this.error.expectIsOpen();
+    await this.errorSelect.expectValue('>> Ignore Exception');
+    await this.throw.expectChecked();
+  }
+  async clear() {
+    await this.errorSelect.choose('ivy:error:email');
+    await this.throw.click();
+  }
+  async assertClear() {
+    await this.error.expectIsClosed();
+  }
+}
+
+export const MailErrorTest = new NewPartTest('Error', (part: Part) => new MailError(part));

--- a/integrations/standalone/tests/integration/parts/mail-header.ts
+++ b/integrations/standalone/tests/integration/parts/mail-header.ts
@@ -1,8 +1,6 @@
-import type { Checkbox } from '../../pageobjects/Checkbox';
 import type { MacroEditor } from '../../pageobjects/CodeEditor';
 import type { Part } from '../../pageobjects/Part';
 import type { Section } from '../../pageobjects/Section';
-import type { Select } from '../../pageobjects/Select';
 import { NewPartTest, PartObject } from './part-tester';
 
 class MailHeader extends PartObject {
@@ -13,9 +11,6 @@ class MailHeader extends PartObject {
   to: MacroEditor;
   cc: MacroEditor;
   bcc: MacroEditor;
-  options: Section;
-  error: Select;
-  throw: Checkbox;
 
   constructor(part: Part) {
     super(part);
@@ -26,9 +21,6 @@ class MailHeader extends PartObject {
     this.to = this.headers.macroInput('To');
     this.cc = this.headers.macroInput('CC');
     this.bcc = this.headers.macroInput('BCC');
-    this.options = part.section('Options');
-    this.error = this.options.select({ label: 'Error' });
-    this.throw = this.options.checkbox('Throw');
   }
 
   async fill() {
@@ -39,10 +31,6 @@ class MailHeader extends PartObject {
     await this.to.fill('to');
     await this.cc.fill('cc');
     await this.bcc.fill('bcc');
-
-    await this.options.toggle();
-    await this.error.choose('>> Ignore Exception');
-    await this.throw.click();
   }
   async assertFill() {
     await this.subject.expectValue('subject');
@@ -51,10 +39,6 @@ class MailHeader extends PartObject {
     await this.to.expectValue('to');
     await this.cc.expectValue('cc');
     await this.bcc.expectValue('bcc');
-
-    await this.options.expectIsOpen();
-    await this.error.expectValue('>> Ignore Exception');
-    await this.throw.expectChecked();
   }
   async clear() {
     await this.subject.clear();
@@ -63,12 +47,9 @@ class MailHeader extends PartObject {
     await this.to.clear();
     await this.cc.clear();
     await this.bcc.clear();
-    await this.error.choose('ivy:error:email');
-    await this.throw.click();
   }
   async assertClear() {
     await this.headers.expectIsClosed();
-    await this.options.expectIsClosed();
   }
 }
 

--- a/integrations/standalone/tests/integration/parts/output.ts
+++ b/integrations/standalone/tests/integration/parts/output.ts
@@ -87,6 +87,6 @@ class OutputEmptyMap extends OutputCode {
   }
 }
 
-export const OutputTest = new NewPartTest('Output Data', (part: Part) => new OutputCode(part));
-export const ScriptOutputTest = new NewPartTest('Output Data', (part: Part) => new OutputCode(part, true));
-export const SignalOutputTest = new NewPartTest('Output Data', (part: Part) => new OutputEmptyMap(part));
+export const OutputTest = new NewPartTest('Output', (part: Part) => new OutputCode(part));
+export const ScriptOutputTest = new NewPartTest('Output', (part: Part) => new OutputCode(part, true));
+export const SignalOutputTest = new NewPartTest('Output', (part: Part) => new OutputEmptyMap(part));

--- a/integrations/standalone/tests/integration/parts/rest-output.ts
+++ b/integrations/standalone/tests/integration/parts/rest-output.ts
@@ -51,4 +51,4 @@ class RestOutput extends PartObject {
   }
 }
 
-export const RestOutputTest = new NewPartTest('Output Data', (part: Part) => new RestOutput(part));
+export const RestOutputTest = new NewPartTest('Output', (part: Part) => new RestOutput(part));

--- a/integrations/standalone/tests/integration/parts/ws-output.ts
+++ b/integrations/standalone/tests/integration/parts/ws-output.ts
@@ -41,4 +41,4 @@ class WsOutput extends PartObject {
   }
 }
 
-export const WsOutputTest = new NewPartTest('Output Data', (part: Part) => new WsOutput(part));
+export const WsOutputTest = new NewPartTest('Output', (part: Part) => new WsOutput(part));

--- a/integrations/standalone/tests/screenshots/activities/interface.spec.ts
+++ b/integrations/standalone/tests/screenshots/activities/interface.spec.ts
@@ -27,7 +27,7 @@ test.describe('Web Service Call', () => {
   });
 
   test('Response Tab', async ({ page }) => {
-    await screenshotAccordion(page, INTERFACE_PID.WS_CALL, 'Output Data', 'web-service-call-tab-response.png');
+    await screenshotAccordion(page, INTERFACE_PID.WS_CALL, 'Output', 'web-service-call-tab-response.png');
   });
 });
 
@@ -69,7 +69,7 @@ test.describe('Rest Client', () => {
   });
 
   test('Response Tab', async ({ page }) => {
-    await screenshotAccordion(page, INTERFACE_PID.REST_POST, 'Output Data', 'rest-client-tab-response.png');
+    await screenshotAccordion(page, INTERFACE_PID.REST_POST, 'Output', 'rest-client-tab-response.png');
   });
 });
 

--- a/packages/editor/src/components/editors/activity/interface.tsx
+++ b/packages/editor/src/components/editors/activity/interface.tsx
@@ -19,7 +19,8 @@ import {
   useProgramInterfaceStartPart,
   useConfigurationPart,
   useRestErrorPart,
-  useDbErrorPart
+  useDbErrorPart,
+  useMailErrorPart
 } from '../../../components/parts';
 import { OpenApiContextProvider } from '../../../context/useOpenApi';
 
@@ -56,9 +57,10 @@ const RestEditor = memo(() => {
 const EMailEditor = memo(() => {
   const name = useGeneralPart();
   const header = useMailHeaderPart();
+  const error = useMailErrorPart();
   const content = useMailMessagePart();
   const attachment = useMailAttachmentPart();
-  return <InscriptionEditor icon={IvyIcons.EMail} parts={[name, header, content, attachment]} />;
+  return <InscriptionEditor icon={IvyIcons.EMail} parts={[name, header, error, content, attachment]} />;
 });
 
 const ProgramInterfaceEditor = memo(() => {

--- a/packages/editor/src/components/editors/gateway/all-gateway-editors.tsx
+++ b/packages/editor/src/components/editors/gateway/all-gateway-editors.tsx
@@ -26,11 +26,11 @@ const SplitEditor = memo(() => {
 
 const TaskSwitchGatewayEditor = memo(() => {
   const name = useGeneralPart();
-  const output = useOutputPart();
   const multiTasks = useMultiTasksPart();
   const casePart = useCasePart();
   const endPage = useEndPagePart();
-  return <InscriptionEditor icon={IvyIcons.JoinTasksGateways} parts={[name, output, multiTasks, casePart, endPage]} />;
+  const output = useOutputPart();
+  return <InscriptionEditor icon={IvyIcons.JoinTasksGateways} parts={[name, multiTasks, casePart, endPage, output]} />;
 });
 
 export const gatewayEditors = new Map<ElementType, ReactNode>([

--- a/packages/editor/src/components/parts/index.ts
+++ b/packages/editor/src/components/parts/index.ts
@@ -14,6 +14,7 @@ export * from './error/ErrorCatchPart';
 export * from './signal/SignalCatchPart';
 export * from './mail/MailHeaderPart';
 export * from './mail/MailMessagePart';
+export * from './mail/MailErrorPart';
 export * from './mail/MailAttachmentPart';
 export * from './trigger/TriggerPart';
 export * from './request/RequestPart';

--- a/packages/editor/src/components/parts/mail/MailErrorPart.test.tsx
+++ b/packages/editor/src/components/parts/mail/MailErrorPart.test.tsx
@@ -1,0 +1,61 @@
+import type { DeepPartial } from 'test-utils';
+import { CollapsableUtil, SelectUtil, render, renderHook, screen } from 'test-utils';
+import type { MailData } from '@axonivy/inscription-protocol';
+import type { PartStateFlag } from '../../editors';
+import { describe, test, expect } from 'vitest';
+import { useMailErrorPart } from './MailErrorPart';
+
+const Part = () => {
+  const part = useMailErrorPart();
+  return <>{part.content}</>;
+};
+
+describe('MailErrorPart', () => {
+  function renderPart(data?: DeepPartial<MailData>) {
+    render(<Part />, { wrapperProps: { data: data && { config: data } } });
+  }
+
+  test('empty data', async () => {
+    renderPart();
+    await CollapsableUtil.assertClosed('Error');
+  });
+
+  test('full data', async () => {
+    const data: DeepPartial<MailData> = {
+      failIfMissingAttachments: true,
+      exceptionHandler: 'f9'
+    };
+    renderPart(data);
+    await CollapsableUtil.assertOpen('Error');
+    await SelectUtil.assertValue('f9');
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  function assertState(expectedState: PartStateFlag, data?: DeepPartial<MailData>) {
+    const { result } = renderHook(() => useMailErrorPart(), { wrapperProps: { data: data && { config: data } } });
+    expect(result.current.state.state).toEqual(expectedState);
+  }
+
+  test('configured', async () => {
+    assertState(undefined);
+    assertState('configured', { failIfMissingAttachments: true });
+    assertState('configured', { exceptionHandler: 'hi' });
+  });
+
+  test('reset', () => {
+    let data = {
+      config: {
+        failIfMissingAttachments: true,
+        exceptionHandler: 'hi'
+      }
+    };
+    const view = renderHook(() => useMailErrorPart(), {
+      wrapperProps: { data, setData: newData => (data = newData), initData: { config: { exceptionHandler: 'init' } } }
+    });
+    expect(view.result.current.reset.dirty).toEqual(true);
+
+    view.result.current.reset.action();
+    expect(data.config.failIfMissingAttachments).toBeFalsy();
+    expect(data.config.exceptionHandler).toEqual('init');
+  });
+});

--- a/packages/editor/src/components/parts/mail/MailErrorPart.tsx
+++ b/packages/editor/src/components/parts/mail/MailErrorPart.tsx
@@ -1,0 +1,45 @@
+import { Checkbox } from '../../widgets';
+import type { PartProps } from '../../editors';
+import { usePartDirty, usePartState } from '../../editors';
+import { useMailData } from './useMailData';
+import type { MailData } from '@axonivy/inscription-protocol';
+import { IVY_EXCEPTIONS } from '@axonivy/inscription-protocol';
+import { PathContext, useValidations } from '../../../context';
+import { ExceptionSelect, ValidationCollapsible } from '../common';
+
+export function useMailErrorPart(): PartProps {
+  const { config, initConfig, defaultConfig, resetError } = useMailData();
+  const compareData = (data: MailData) => [data.exceptionHandler, data.failIfMissingAttachments];
+  const exceptionValidations = useValidations(['exceptionHandler']);
+  const state = usePartState(compareData(defaultConfig), compareData(config), exceptionValidations);
+  const dirty = usePartDirty(compareData(initConfig), compareData(config));
+  return { name: 'Error', state, reset: { dirty, action: () => resetError() }, content: <MailErrorPart /> };
+}
+
+const MailErrorPart = () => {
+  const { config, defaultConfig, update } = useMailData();
+
+  return (
+    <>
+      <ValidationCollapsible
+        label='Error'
+        defaultOpen={config.failIfMissingAttachments || config.exceptionHandler !== defaultConfig.exceptionHandler}
+      >
+        <PathContext path='exceptionHandler'>
+          <ExceptionSelect
+            value={config.exceptionHandler}
+            onChange={change => update('exceptionHandler', change)}
+            staticExceptions={[IVY_EXCEPTIONS.mail, IVY_EXCEPTIONS.ignoreException]}
+          />
+        </PathContext>
+        <Checkbox
+          label='Throw an error if any attachment is missing'
+          value={config.failIfMissingAttachments}
+          onChange={change => {
+            update('failIfMissingAttachments', change);
+          }}
+        />
+      </ValidationCollapsible>
+    </>
+  );
+};

--- a/packages/editor/src/components/parts/mail/MailHeaderPart.test.tsx
+++ b/packages/editor/src/components/parts/mail/MailHeaderPart.test.tsx
@@ -1,5 +1,5 @@
 import type { DeepPartial } from 'test-utils';
-import { CollapsableUtil, SelectUtil, render, renderHook, screen } from 'test-utils';
+import { CollapsableUtil, render, renderHook, screen } from 'test-utils';
 import type { MailData } from '@axonivy/inscription-protocol';
 import type { PartStateFlag } from '../../editors';
 import { useMailHeaderPart } from './MailHeaderPart';
@@ -22,22 +22,16 @@ describe('MailHeaderPart', () => {
     expect(screen.getByLabelText('To')).toHaveValue(data?.headers?.to ?? '');
     expect(screen.getByLabelText('CC')).toHaveValue(data?.headers?.cc ?? '');
     expect(screen.getByLabelText('BCC')).toHaveValue(data?.headers?.bcc ?? '');
-    await CollapsableUtil.assertOpen('Options');
-    await SelectUtil.assertValue('f9');
-    expect(screen.getByRole('checkbox')).toBeChecked();
   }
 
   test('empty data', async () => {
     renderPart();
     await CollapsableUtil.assertClosed('Headers');
-    await CollapsableUtil.assertClosed('Options');
   });
 
   test('full data', async () => {
     const data: DeepPartial<MailData> = {
-      headers: { subject: 'sub', from: 'from', replyTo: 'reply', to: 'to', cc: 'cc', bcc: 'bcc' },
-      failIfMissingAttachments: true,
-      exceptionHandler: 'f9'
+      headers: { subject: 'sub', from: 'from', replyTo: 'reply', to: 'to', cc: 'cc', bcc: 'bcc' }
     };
     renderPart(data);
     await assertPage(data);
@@ -56,16 +50,12 @@ describe('MailHeaderPart', () => {
     assertState('configured', { headers: { replyTo: 's' } });
     assertState('configured', { headers: { cc: 's' } });
     assertState('configured', { headers: { bcc: 's' } });
-    assertState('configured', { failIfMissingAttachments: true });
-    assertState('configured', { exceptionHandler: 'hi' });
   });
 
   test('reset', () => {
     let data = {
       config: {
-        headers: { subject: 'sub', from: 'from', replyTo: 'reply', to: 'to', cc: 'cc', bcc: 'bcc' },
-        failIfMissingAttachments: true,
-        exceptionHandler: 'hi'
+        headers: { subject: 'sub', from: 'from', replyTo: 'reply', to: 'to', cc: 'cc', bcc: 'bcc' }
       }
     };
     const view = renderHook(() => useMailHeaderPart(), {
@@ -80,7 +70,5 @@ describe('MailHeaderPart', () => {
     expect(data.config.headers.cc).toEqual('');
     expect(data.config.headers.bcc).toEqual('');
     expect(data.config.headers.to).toEqual('');
-    expect(data.config.failIfMissingAttachments).toBeFalsy();
-    expect(data.config.exceptionHandler).toEqual('');
   });
 });

--- a/packages/editor/src/components/parts/mail/MailHeaderPart.tsx
+++ b/packages/editor/src/components/parts/mail/MailHeaderPart.tsx
@@ -1,26 +1,24 @@
-import { Checkbox, MacroInput } from '../../widgets';
+import { MacroInput } from '../../widgets';
 import type { PartProps } from '../../editors';
 import { usePartDirty, usePartState } from '../../editors';
 import { useMailData } from './useMailData';
 import type { MailData } from '@axonivy/inscription-protocol';
-import { IVY_EXCEPTIONS } from '@axonivy/inscription-protocol';
 import { useValidations } from '../../../context';
-import { ExceptionSelect, PathCollapsible, PathFieldset, ValidationCollapsible } from '../common';
+import { PathCollapsible, PathFieldset } from '../common';
 import type { BrowserType } from '../../../components/browser';
 import { deepEqual } from '../../../utils/equals';
 
 export function useMailHeaderPart(): PartProps {
   const { config, initConfig, defaultConfig, resetHeaders } = useMailData();
-  const compareData = (data: MailData) => [data.headers, data.failIfMissingAttachments, data.exceptionHandler];
+  const compareData = (data: MailData) => [data.headers];
   const headerValidations = useValidations(['headers']);
-  const exceptionValidations = useValidations(['exceptionHandler']);
-  const state = usePartState(compareData(defaultConfig), compareData(config), [...headerValidations, ...exceptionValidations]);
+  const state = usePartState(compareData(defaultConfig), compareData(config), headerValidations);
   const dirty = usePartDirty(compareData(initConfig), compareData(config));
   return { name: 'Header', state, reset: { dirty, action: () => resetHeaders() }, content: <MailHeaderPart /> };
 }
 
 const MailHeaderPart = () => {
-  const { config, defaultConfig, update, updateHeader } = useMailData();
+  const { config, defaultConfig, updateHeader } = useMailData();
   const borwserTypes: BrowserType[] = ['attr', 'func', 'cms'];
 
   return (
@@ -45,25 +43,6 @@ const MailHeaderPart = () => {
           <MacroInput value={config.headers.bcc} onChange={change => updateHeader('bcc', change)} browsers={borwserTypes} />
         </PathFieldset>
       </PathCollapsible>
-      <ValidationCollapsible
-        label='Options'
-        defaultOpen={config.failIfMissingAttachments || config.exceptionHandler !== defaultConfig.exceptionHandler}
-      >
-        <PathFieldset label='Error' path='exceptionHandler'>
-          <ExceptionSelect
-            value={config.exceptionHandler}
-            onChange={change => update('exceptionHandler', change)}
-            staticExceptions={[IVY_EXCEPTIONS.mail, IVY_EXCEPTIONS.ignoreException]}
-          />
-        </PathFieldset>
-        <Checkbox
-          label='Throw an error if any attachment is missing'
-          value={config.failIfMissingAttachments}
-          onChange={change => {
-            update('failIfMissingAttachments', change);
-          }}
-        />
-      </ValidationCollapsible>
     </>
   );
 };

--- a/packages/editor/src/components/parts/mail/useMailData.ts
+++ b/packages/editor/src/components/parts/mail/useMailData.ts
@@ -1,4 +1,4 @@
-import type { ConfigDataContext} from '../../../context';
+import type { ConfigDataContext } from '../../../context';
 import { useConfigDataContext } from '../../../context';
 import type { MailData } from '@axonivy/inscription-protocol';
 import { produce } from 'immer';
@@ -10,6 +10,7 @@ export function useMailData(): ConfigDataContext<MailData> & {
   resetHeaders: () => void;
   updateMessage: DataUpdater<MailData['message']>;
   resetMessage: () => void;
+  resetError: () => void;
   resetAttachments: () => void;
 } {
   const { setConfig, ...config } = useConfigDataContext();
@@ -32,8 +33,6 @@ export function useMailData(): ConfigDataContext<MailData> & {
     setConfig(
       produce(draft => {
         draft.headers = config.initConfig.headers;
-        draft.failIfMissingAttachments = config.initConfig.failIfMissingAttachments;
-        draft.exceptionHandler = config.initConfig.exceptionHandler;
       })
     );
 
@@ -58,6 +57,14 @@ export function useMailData(): ConfigDataContext<MailData> & {
       })
     );
 
+  const resetError = () =>
+    setConfig(
+      produce(draft => {
+        draft.exceptionHandler = config.initConfig.exceptionHandler;
+        draft.failIfMissingAttachments = config.initConfig.failIfMissingAttachments;
+      })
+    );
+
   return {
     ...config,
     update,
@@ -65,6 +72,7 @@ export function useMailData(): ConfigDataContext<MailData> & {
     resetHeaders,
     updateMessage,
     resetMessage,
+    resetError,
     resetAttachments
   };
 }

--- a/packages/editor/src/components/parts/output/OutputPart.tsx
+++ b/packages/editor/src/components/parts/output/OutputPart.tsx
@@ -15,7 +15,7 @@ export function useOutputPart(options?: { showSudo?: boolean; additionalBrowsers
   const state = usePartState(compareData(defaultConfig), compareData(config), validations);
   const dirty = usePartDirty(compareData(initConfig), compareData(config));
   return {
-    name: 'Output Data',
+    name: 'Output',
     state,
     reset: { dirty, action: () => resetOutput(options?.showSudo) },
     content: <OutputPart showSudo={options?.showSudo} additionalBrowsers={options?.additionalBrowsers} />

--- a/packages/editor/src/components/parts/rest/RestOutputPart.tsx
+++ b/packages/editor/src/components/parts/rest/RestOutputPart.tsx
@@ -16,7 +16,7 @@ export function useRestOutputPart(): PartProps {
   const compareData = (data: RestResponseData) => [data.response.entity];
   const state = usePartState(compareData(defaultConfig), compareData(config), filteredOutputValidations);
   const dirty = usePartDirty(compareData(initConfig), compareData(config));
-  return { name: 'Output Data', state: state, reset: { dirty, action: () => resetData() }, content: <RestOutputPart /> };
+  return { name: 'Output', state: state, reset: { dirty, action: () => resetData() }, content: <RestOutputPart /> };
 }
 
 const useShowResultTypeCombo = (types: string[], currentType: string) => {


### PR DESCRIPTION
I discussed the following points again with bruno and have now adjusted them:
- Output Data changed back to Output, as it is better to have only one word
- In the mail: Error section moved to its own (new) Error tab (analogous to the other elements, e.g. Rest...)
- Task-Switch-Gateway: Output-Tab was moved to the end like the other tabs