### PR TITLE
XIVY-14079: For Codeblock - Adjust initHeight, scrollPosition & scrollShadow

### DIFF
--- a/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ScriptArea.tsx
@@ -25,6 +25,14 @@ const ScriptArea = (props: ScriptAreaProps) => {
       props.maximizeState.setIsMaximizedCodeEditorOpen(true);
     });
   };
+  const setScrollPosition = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    const text = editor.getValue();
+    const importRegex = /^import .+;/gm;
+    const importMatches = text.match(importRegex);
+    const importAmount = importMatches ? importMatches.length : 0;
+    editor.revealLine(importAmount + 1);
+  };
+
   const { inputProps } = useField();
 
   return (
@@ -40,7 +48,13 @@ const ScriptArea = (props: ScriptAreaProps) => {
       />
       {!props.maximizeState.isMaximizedCodeEditorOpen && (
         <div className='script-area'>
-          <ResizableCodeEditor {...inputProps} {...props} location={path} onMountFuncs={[setEditor, keyActionMountFunc]} />
+          <ResizableCodeEditor
+            {...inputProps}
+            {...props}
+            initHeight={props.value.length > 0 ? 250 : undefined}
+            location={path}
+            onMountFuncs={[setEditor, keyActionMountFunc, setScrollPosition]}
+          />
           <Browser {...browser} types={props.browsers} accept={modifyEditor} location={path} initSearchFilter={getMonacoSelection} />
         </div>
       )}

--- a/packages/editor/src/monaco/monaco-editor-util.ts
+++ b/packages/editor/src/monaco/monaco-editor-util.ts
@@ -24,7 +24,10 @@ export const MONACO_OPTIONS: editor.IStandaloneEditorConstructionOptions = {
   fontSize: 12,
   tabSize: 2,
   renderWhitespace: 'all',
-  fixedOverflowWidgets: true
+  fixedOverflowWidgets: true,
+  scrollbar: {
+    useShadows: false
+  }
 };
 
 export const MAXIMIZED_MONACO_OPTIONS: editor.IStandaloneEditorConstructionOptions = {


### PR DESCRIPTION
I have improved the code block as follows (in minimized view):
- Autoscroll to the first line where there is no import
- If codeblock is empty the height is set to 90 and otherwise to 250
- When scrolling there is no shadow on top anymore (bruno didn't like it)