### PR TITLE
Max code editor in script cell

### DIFF
--- a/packages/editor/src/components/parts/query/database/Condition.tsx
+++ b/packages/editor/src/components/parts/query/database/Condition.tsx
@@ -2,17 +2,27 @@ import { PathContext } from '../../../../context';
 import { MacroArea } from '../../../../components/widgets';
 import { PathCollapsible, ValidationFieldset } from '../../common';
 import { useQueryData } from '../useQueryData';
+import useMaximizedCodeEditor from '../../../browser/useMaximizedCodeEditor';
 
 export const Condition = () => {
   const { config, defaultConfig, updateSql } = useQueryData();
+
+  const { maximizeState, maximizeCode } = useMaximizedCodeEditor();
+
   return (
     <PathContext path='sql'>
-      <PathCollapsible label='Condition' defaultOpen={config.query.sql.condition !== defaultConfig.query.sql.condition} path='condition'>
+      <PathCollapsible
+        label='Condition'
+        controls={[maximizeCode]}
+        defaultOpen={config.query.sql.condition !== defaultConfig.query.sql.condition}
+        path='condition'
+      >
         <ValidationFieldset>
           <MacroArea
             value={config.query.sql.condition}
             onChange={change => updateSql('condition', change)}
             browsers={['tablecol', 'attr']}
+            maximizeState={maximizeState}
           />
         </ValidationFieldset>
       </PathCollapsible>

--- a/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
@@ -9,11 +9,12 @@ import type { ElementRef } from 'react';
 import { useRef } from 'react';
 import { useOnFocus } from '../../../components/browser/useOnFocus';
 import { useField } from '@axonivy/ui-components';
+import MaximizedCodeEditorBrowser from '../../browser/MaximizedCodeEditorBrowser';
 
 const MacroArea = ({ value, onChange, browsers, ...props }: CodeEditorAreaProps) => {
   const { isFocusWithin, focusWithinProps, focusValue } = useOnFocus(value, onChange);
   const browser = useBrowser();
-  const { setEditor, modifyEditor } = useMonacoEditor({ modifyAction: value => `<%=${value}%>` });
+  const { setEditor, modifyEditor, getSelectionRange } = useMonacoEditor({ modifyAction: value => `<%=${value}%>` });
   const path = usePath();
   const areaRef = useRef<ElementRef<'output'>>(null);
   const { inputProps } = useField();
@@ -21,18 +22,33 @@ const MacroArea = ({ value, onChange, browsers, ...props }: CodeEditorAreaProps)
   return (
     // tabIndex is needed for safari to catch the focus when click on browser button
     <div className='script-area' {...focusWithinProps} tabIndex={1}>
-      {isFocusWithin || browser.open ? (
+      {isFocusWithin || browser.open || props.maximizeState?.isMaximizedCodeEditorOpen ? (
         <>
-          <ResizableCodeEditor
-            {...focusValue}
-            {...inputProps}
-            {...props}
-            location={path}
-            onMountFuncs={[setEditor, monacoAutoFocus]}
-            macro={true}
-            initHeight={areaRef.current?.offsetHeight}
-          />
-          <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
+          {props.maximizeState && (
+            <MaximizedCodeEditorBrowser
+              open={props.maximizeState.isMaximizedCodeEditorOpen}
+              onOpenChange={props.maximizeState.setIsMaximizedCodeEditorOpen}
+              browsers={browsers}
+              editorValue={value}
+              location={path}
+              applyEditor={focusValue.onChange}
+              selectionRange={getSelectionRange()}
+            />
+          )}
+          {!props.maximizeState?.isMaximizedCodeEditorOpen && (
+            <>
+              <ResizableCodeEditor
+                {...focusValue}
+                {...inputProps}
+                {...props}
+                location={path}
+                onMountFuncs={[setEditor, monacoAutoFocus]}
+                macro={true}
+                initHeight={areaRef.current?.offsetHeight}
+              />
+              <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
+            </>
+          )}
         </>
       ) : (
         <CardArea value={value} {...inputProps} {...props} ref={areaRef} />

--- a/packages/editor/src/components/widgets/code-editor/ResizableCodeEditor.tsx
+++ b/packages/editor/src/components/widgets/code-editor/ResizableCodeEditor.tsx
@@ -7,6 +7,10 @@ import type { BrowserType } from '../../../components/browser';
 
 export type CodeEditorAreaProps = Omit<ResizableCodeEditorProps, 'macro' | 'options' | 'onMount' | 'location'> & {
   browsers: BrowserType[];
+  maximizeState?: {
+    isMaximizedCodeEditorOpen: boolean;
+    setIsMaximizedCodeEditorOpen: (open: boolean) => void;
+  };
 };
 
 type ResizableCodeEditorProps = Omit<CodeEditorProps, 'height' | 'context'> & {

--- a/packages/editor/src/components/widgets/code-editor/index.ts
+++ b/packages/editor/src/components/widgets/code-editor/index.ts
@@ -3,3 +3,4 @@ export { default as ScriptInput } from './ScriptInput';
 export { default as MacroArea } from './MacroArea';
 export { default as MacroInput } from './MacroInput';
 export { default as SingleLineCodeEditor } from './SingleLineCodeEditor';
+export { default as MaximizedCodeEditorBrowser } from '../../browser/MaximizedCodeEditorBrowser';

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.css
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.css
@@ -25,10 +25,18 @@
   border-radius: 0px;
 }
 
+.ui-table-cell .script-input .code-editor .code-input {
+  padding-right: 55px;
+}
+
 .ui-table-cell .script-input .ui-button {
   color: var(--body);
 }
 
 .ui-table-cell .code-editor .code-input {
   border-radius: 0px;
+}
+
+.ui-table-cell .maximize-code-button {
+  margin-right: 30px;
 }

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -3,11 +3,13 @@ import type { CellContext } from '@tanstack/react-table';
 import { useEffect, useState } from 'react';
 import { usePath } from '../../../../context';
 import { Input } from '../../input';
-import { SingleLineCodeEditor } from '../../code-editor';
+import { MaximizedCodeEditorBrowser, SingleLineCodeEditor } from '../../code-editor';
 import type { BrowserType } from '../../../browser';
 import { Browser, useBrowser } from '../../../browser';
 import { useMonacoEditor } from '../../code-editor/useCodeEditor';
 import { useOnFocus } from '../../../browser/useOnFocus';
+import useMaximizedCodeEditor from '../../../browser/useMaximizedCodeEditor';
+import { Button } from '@axonivy/ui-components';
 
 type CodeEditorCellProps<TData> = {
   cell: CellContext<TData, string>;
@@ -25,13 +27,15 @@ export function CodeEditorCell<TData>({ cell, makro, type, browsers, placeholder
     setValue(initialValue);
   }, [initialValue]);
 
-  const { setEditor, modifyEditor } = useMonacoEditor();
+  const { setEditor, modifyEditor, getSelectionRange } = useMonacoEditor();
   const path = usePath();
   const browser = useBrowser();
 
+  const { maximizeState, maximizeCode } = useMaximizedCodeEditor();
+
   const updateValue = (newValue: string) => {
     setValue(newValue);
-    if (!browser.open && newValue !== cell.getValue()) {
+    if (!browser.open && newValue !== cell.getValue() && !maximizeState.isMaximizedCodeEditorOpen) {
       cell.table.options.meta?.updateData(cell.row.id, cell.column.id, newValue);
     }
   };
@@ -53,19 +57,40 @@ export function CodeEditorCell<TData>({ cell, makro, type, browsers, placeholder
 
   return (
     <div className='script-input' {...focusWithinProps} tabIndex={1}>
-      {isFocusWithin || browser.open ? (
+      {isFocusWithin || browser.open || maximizeState.isMaximizedCodeEditorOpen ? (
         <>
-          <SingleLineCodeEditor
-            {...focusValue}
-            context={{ type, location: path }}
-            keyActions={{
-              enter: activeElementBlur,
-              escape: activeElementBlur
-            }}
-            onMountFuncs={[setEditor]}
-            macro={makro}
+          <MaximizedCodeEditorBrowser
+            open={maximizeState.isMaximizedCodeEditorOpen}
+            onOpenChange={maximizeState.setIsMaximizedCodeEditorOpen}
+            browsers={browsers}
+            editorValue={value}
+            location={path}
+            applyEditor={focusValue.onChange}
+            selectionRange={getSelectionRange()}
           />
-          <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
+          {!maximizeState.isMaximizedCodeEditorOpen && (
+            <>
+              <SingleLineCodeEditor
+                {...focusValue}
+                context={{ type, location: path }}
+                keyActions={{
+                  enter: activeElementBlur,
+                  escape: activeElementBlur
+                }}
+                onMountFuncs={[setEditor]}
+                macro={makro}
+              />
+
+              <Browser {...browser} types={browsers} accept={modifyEditor} location={path} />
+            </>
+          )}
+          <Button
+            className='maximize-code-button'
+            onClick={maximizeCode.action}
+            title={maximizeCode.label}
+            toggle={maximizeCode.active}
+            icon={maximizeCode.icon}
+          />
         </>
       ) : (
         <Input value={value} onChange={setValue} placeholder={placeholder} onBlur={() => updateValue(value)} />

--- a/packages/editor/src/test-utils/setupTests.tsx
+++ b/packages/editor/src/test-utils/setupTests.tsx
@@ -50,7 +50,8 @@ vi.mock('../components/widgets/code-editor', () => ({
   ScriptInput: CodeEditorMock,
   MacroArea: CodeEditorMock,
   MacroInput: CodeEditorMock,
-  SingleLineCodeEditor: CodeEditorMock
+  SingleLineCodeEditor: CodeEditorMock,
+  MaximizedCodeEditorBrowser: CodeEditorMock
 }));
 
 window.HTMLElement.prototype.scrollIntoView = vi.fn();


### PR DESCRIPTION
I have added an additional expand button to all CodeEditorCells within the monaco editor as well as an expand icon to the condition tab of the database element in the header.

The monaco can now be opened in fullscreen for both.

![beispiel_Expand](https://github.com/axonivy/inscription-client/assets/141223521/4a01972f-1cb6-427f-b390-edd0485aa3e0)
