### PR TITLE
XIVY-14079: Fix validation for maximized code-editor

### DIFF
--- a/packages/editor/src/components/browser/MaximizedCodeEditorBrowser.tsx
+++ b/packages/editor/src/components/browser/MaximizedCodeEditorBrowser.tsx
@@ -14,7 +14,9 @@ const MaximizedCodeEditorBrowser = ({
   editorValue,
   applyEditor,
   location,
-  selectionRange
+  selectionRange,
+  macro,
+  type
 }: MaximaziedCodeEditorBrowserProps) => {
   const tabs: Tab[] = [
     {
@@ -31,6 +33,8 @@ const MaximizedCodeEditorBrowser = ({
               onOpenChange(false);
             }
           }}
+          type={type}
+          macro={macro}
         />
       ),
       id: 'maxCode',

--- a/packages/editor/src/components/browser/maximizedCodeEditor/MaximizedCodeEditor.tsx
+++ b/packages/editor/src/components/browser/maximizedCodeEditor/MaximizedCodeEditor.tsx
@@ -16,6 +16,8 @@ export type MaximizedCodeEditorProps = {
   keyActions?: {
     escape?: () => void;
   };
+  macro?: boolean;
+  type?: string;
 };
 
 const MaximizedCodeEditor = ({
@@ -25,9 +27,11 @@ const MaximizedCodeEditor = ({
   applyEditor,
   selectionRange,
   keyActions,
+  macro,
+  type,
   open
 }: MaximizedCodeEditorProps) => {
-  const { setEditor, modifyEditor, getMonacoSelection } = useMonacoEditor();
+  const { setEditor, modifyEditor, getMonacoSelection } = useMonacoEditor(macro ? { modifyAction: value => `<%=${value}%>` } : undefined);
   const browser = useBrowser();
 
   const setSelection = (editor: monaco.editor.IStandaloneCodeEditor) => {
@@ -62,9 +66,10 @@ const MaximizedCodeEditor = ({
           <CodeEditor
             value={editorValue}
             onChange={applyEditor}
-            context={{ location }}
+            context={{ type, location }}
             onMountFuncs={[setEditor, delayedMonacoAutoFocus, setSelection, keyActionMountFunc]}
             options={MAXIMIZED_MONACO_OPTIONS}
+            macro={macro}
           />
         </div>
         <Browser {...browser} types={browsers} accept={modifyEditor} location={location} initSearchFilter={getMonacoSelection} />

--- a/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
+++ b/packages/editor/src/components/widgets/code-editor/MacroArea.tsx
@@ -33,6 +33,7 @@ const MacroArea = ({ value, onChange, browsers, ...props }: CodeEditorAreaProps)
               location={path}
               applyEditor={focusValue.onChange}
               selectionRange={getSelectionRange()}
+              macro={true}
             />
           )}
           {!props.maximizeState?.isMaximizedCodeEditorOpen && (

--- a/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/editor/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -67,6 +67,8 @@ export function CodeEditorCell<TData>({ cell, makro, type, browsers, placeholder
             location={path}
             applyEditor={focusValue.onChange}
             selectionRange={getSelectionRange()}
+            macro={makro}
+            type={type}
           />
           {!maximizeState.isMaximizedCodeEditorOpen && (
             <>


### PR DESCRIPTION
In order for the maximized code editor (which I added to the expression cells and the condition in the db element), to display the correct validations in monaco, I had to forward the macro and type attributes.