### PR TITLE
XIVY-14204 fix: NPE for Database TableFields

### DIFF
--- a/packages/editor/src/components/parts/query/database/TableFields.tsx
+++ b/packages/editor/src/components/parts/query/database/TableFields.tsx
@@ -21,7 +21,7 @@ export const TableFields = () => {
   const [data, setData] = useState<Column[]>([]);
 
   useEffect(() => {
-    const fields = config.query.sql.fields;
+    const fields = config.query.sql.fields ?? {};
     const columnData = columnMetas.map<Column>(c => {
       return { ...c, expression: fields[c.name] ?? '' };
     });
@@ -91,7 +91,11 @@ export const TableFields = () => {
 
   return (
     <PathContext path='sql'>
-      <PathCollapsible label='Fields' path='fields' defaultOpen={Object.keys(config.query.sql.fields).length > 0}>
+      <PathCollapsible
+        label='Fields'
+        path='fields'
+        defaultOpen={config.query.sql.fields && Object.keys(config.query.sql.fields).length > 0}
+      >
         <Table>
           <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={() => setRowSelection({})} />
           <TableBody>


### PR DESCRIPTION
If you select Any in the Database element and reload the Inscription and switch to another query (where the TableFields component is used), an NPE appears because config.query.sql.fields are undefined but are used within the TableFields component. 

With this fix NPE does not appear anymore, but I am not sure if this is the best way. What do you think?

https://1ivy.atlassian.net/browse/XIVY-14204