### PR TITLE
XIVY-14204 Fix: NPE for Database-READ TableSort

### DIFF
--- a/packages/editor/src/components/parts/query/database/Condition.tsx
+++ b/packages/editor/src/components/parts/query/database/Condition.tsx
@@ -14,7 +14,7 @@ export const Condition = () => {
       <PathCollapsible
         label='Condition'
         controls={[maximizeCode]}
-        defaultOpen={config.query.sql.condition !== defaultConfig.query.sql.condition}
+        defaultOpen={config.query.sql.condition !== defaultConfig.query.sql.condition && config.query.sql.condition !== undefined}
         path='condition'
       >
         <ValidationFieldset>

--- a/packages/editor/src/components/parts/query/database/TableReadFields.tsx
+++ b/packages/editor/src/components/parts/query/database/TableReadFields.tsx
@@ -14,7 +14,7 @@ type Column = Omit<DatabaseColumn, 'ivyType'> & {
 
 export const TableReadFields = () => {
   const { config, updateSql } = useQueryData();
-  const selectAll = config.query.sql.select?.length === 1 && config.query.sql.select[0] === '*';
+  const selectAll = !config.query.sql.select || (config.query.sql.select?.length === 1 && config.query.sql.select[0] === '*');
 
   const { elementContext: context } = useEditorContext();
   const columnMetas = useMeta('meta/database/columns', { context, database: config.query.dbName, table: config.query.sql.table }, []).data;

--- a/packages/editor/src/components/parts/query/database/TableSort.tsx
+++ b/packages/editor/src/components/parts/query/database/TableSort.tsx
@@ -43,7 +43,7 @@ export const TableSort = () => {
   const orderItems = useMemo<SelectItem[]>(() => Object.entries(QUERY_ORDER).map(([label, value]) => ({ label, value })), []);
 
   useEffect(() => {
-    const data = config.query.sql.orderBy.map<Column>(order => {
+    const data = config.query.sql.orderBy?.map<Column>(order => {
       const parts = order.split(' ');
       const name = parts[0];
       let sorting: OrderDirection = 'ASCENDING';
@@ -52,7 +52,7 @@ export const TableSort = () => {
       }
       return { name, sorting };
     });
-    setData(data);
+    setData(data ?? []);
   }, [config.query.sql.orderBy]);
 
   const columns = useMemo<ColumnDef<Column, string>[]>(


### PR DESCRIPTION
- As with TableFields, an NPE occurred when switching from ANY to READ because orderBy was undefined.
- In addition, the defaultOpen was corrected accordingly.
- I wasn't quite sure if there was a shorter way of writing but I don't think so for these situations.