### PR TITLE
Fix: Spacing between card-text-line with auto-word-wrap

### DIFF
--- a/packages/editor/src/components/widgets/output/CardText.css
+++ b/packages/editor/src/components/widgets/output/CardText.css
@@ -12,8 +12,12 @@
   overflow: hidden;
   min-height: 14px;
 }
+
+.card-text > .card-text-line {
+  line-height: 25px;
+}
+
 .card-text .card-text-line {
-  height: 20px;
   white-space: pre-wrap;
 }
 
@@ -30,6 +34,5 @@
   margin-right: var(--size-1);
   display: inline-block;
   width: 1em;
-  height: 1em;
-  vertical-align: bottom;
+  vertical-align: middle;
 }


### PR DESCRIPTION
The issue was that our custom text splitting into multiple CardLines maintained a 20px gap between them. However, if a span within a CardLine contained text longer than the card text div, it wrapped onto a new line, and this extra line wasn't considered when calculating the spacing for the subsequent CardLines.

I've now set the line-height to initial. If you prefer a larger gap between lines, you can set it to 20px, for instance.

Before:
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/f1ae053a-a2ba-4c1b-8512-4538491403c4)

After:
![grafik](https://github.com/axonivy/inscription-client/assets/141223521/ce26a726-b3a7-4b0f-b3f3-34fa2cc30b2f)
