### PR TITLE
Improve it tests

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,9 +7,6 @@
       "label": "Start Dev Server",
       "type": "shell",
       "command": "yarn dev",
-      "windows": {
-        "command": "yarn standalone start:mock:win"
-      },
       "problemMatcher": [
         {
           "owner": "typescript",

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
           docker.build('node-webtest', '-f build/playwright/Dockerfile .').inside {
             sh 'build/use-mirror-npm.sh'
             sh 'yarn install'
+            sh 'yarn package'
             dir ('integrations/standalone/tests/integration/project') {
               maven cmd: "-ntp verify -Dengine.page.url=${params.engineSource}"
             }

--- a/build/screenshots/Jenkinsfile
+++ b/build/screenshots/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
           docker.build('node-webtest', '-f build/playwright/Dockerfile .').inside {
             sh 'build/use-mirror-npm.sh'
             sh 'yarn install'
+            sh 'yarn package'
             dir ('integrations/standalone/tests/screenshots/project') {
               maven cmd: "-ntp verify -Dengine.page.url=${params.engineSource}"
             }

--- a/integrations/standalone/package.json
+++ b/integrations/standalone/package.json
@@ -35,8 +35,6 @@
     "package": "vite build",
     "type": "tsc --noEmit",
     "start": "vite",
-    "start:mock": "MOCK=true vite",
-    "start:mock:win": "SET MOCK=true&& vite",
     "serve": "vite preview",
     "lint": "eslint --ext .ts,.tsx ./src ./tests",
     "lint:fix": "eslint --fix --ext .ts,.tsx ./src ./tests",

--- a/integrations/standalone/playwright.base.ts
+++ b/integrations/standalone/playwright.base.ts
@@ -27,7 +27,7 @@ const config = defineConfig({
   reporter: process.env.CI ? [['../custom-reporter.ts'], ['junit', { outputFile: 'report.xml' }], ['list']] : 'html',
   use: {
     actionTimeout: 0,
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:3000',
     trace: 'retain-on-failure',
     headless: process.env.CI ? true : false
   },

--- a/integrations/standalone/tests/integration/playwright.config.ts
+++ b/integrations/standalone/tests/integration/playwright.config.ts
@@ -4,8 +4,8 @@ import defaultConfig from '../../playwright.base';
 export default defineConfig(defaultConfig, {
   testDir: './',
   webServer: {
-    command: 'yarn start',
-    url: 'http://localhost:3000',
+    command: 'yarn serve',
+    url: process.env.CI ? 'http://localhost:4173' : 'http://localhost:3000',
     reuseExistingServer: !process.env.CI
   }
 });

--- a/integrations/standalone/tests/mock/playwright.config.ts
+++ b/integrations/standalone/tests/mock/playwright.config.ts
@@ -1,16 +1,18 @@
 import { defineConfig } from '@playwright/test';
 import defaultConfig from '../../playwright.base';
 
+const baseUrl = process.env.CI ? 'http://localhost:4173/mock.html' : 'http://localhost:3000/mock.html';
+
 export default defineConfig(defaultConfig, {
   testDir: './',
   timeout: 1000 * 60,
   use: {
-    baseURL: 'http://localhost:3000/mock.html'
+    baseURL: baseUrl
   },
   retries: process.env.CI ? 1 : 0,
   webServer: {
-    command: 'yarn start:mock',
-    url: 'http://localhost:3000/mock.html',
+    command: 'yarn serve',
+    url: baseUrl,
     reuseExistingServer: !process.env.CI
   }
 });

--- a/integrations/standalone/tests/screenshots/activities/interface.spec.ts
+++ b/integrations/standalone/tests/screenshots/activities/interface.spec.ts
@@ -88,8 +88,12 @@ test.describe('Email', () => {
 });
 
 test.describe('Rule', () => {
-  test.skip('Call Tab', async ({ page }) => {
-    await screenshotAccordion(page, INTERFACE_PID.RULE, 'Call', 'rule-tab-call.png');
+  test('Error Tab', async ({ page }) => {
+    await screenshotAccordion(page, INTERFACE_PID.RULE, 'Error', 'rule-tab-error.png');
+  });
+
+  test('Configuration Tab', async ({ page }) => {
+    await screenshotAccordion(page, INTERFACE_PID.RULE, 'Configuration', 'rule-tab-configuration.png');
   });
 });
 

--- a/integrations/standalone/tests/screenshots/playwright.config.ts
+++ b/integrations/standalone/tests/screenshots/playwright.config.ts
@@ -13,9 +13,10 @@ export default defineConfig(defaultConfig, {
       }
     }
   ],
+  timeout: 1000 * 60,
   webServer: {
-    command: 'yarn start',
-    url: 'http://localhost:3000',
+    command: 'yarn serve',
+    url: process.env.CI ? 'http://localhost:4173' : 'http://localhost:3000',
     reuseExistingServer: !process.env.CI
   }
 });

--- a/integrations/standalone/vite.config.ts
+++ b/integrations/standalone/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(() => {
         }
       }
     },
-    server: { port: 3000, open: true },
+    server: { port: 3000 },
     resolve: {
       alias: {
         path: 'path-browserify',
@@ -40,8 +40,5 @@ export default defineConfig(() => {
       ]
     }
   };
-  if (process.env.MOCK) {
-    config.server!.open = false;
-  }
   return config;
 });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:ci": "yarn lint -o eslint.xml -f checkstyle",
     "lint:fix": "lerna run lint:fix --",
     "standalone": "yarn -s --cwd integrations/standalone",
-    "dev": "yarn standalone start:mock",
+    "dev": "yarn standalone start",
     "generate": "lerna run generate",
     "protocol": "yarn --cwd packages/protocol",
     "test": "yarn --cwd packages/editor test",


### PR DESCRIPTION
Seems to increase playwright tests speed about 30%. 
- only chrome: new ~5min, old ~8min
- all: new ~19min, old ~30min

This may be enough that the tests run more stable in the night, otherwise, I will invest further...

And we should also convert this repo to npm and streamline the commands :)