### PR TITLE
XIVY-14428 Improve Combobox design and responsivness

### DIFF
--- a/packages/editor/src/components/parts/call/CallSelect.tsx
+++ b/packages/editor/src/components/parts/call/CallSelect.tsx
@@ -39,11 +39,9 @@ const CallSelect = ({ start, onChange, starts, startIcon }: CallSelectProps) => 
       <>
         <div>
           <IvyIcon icon={startIcon} />
-          <span style={item.deprecated ? { textDecoration: 'line-through' } : {}}>{item.startName}</span>
+          <span style={item.deprecated ? { textDecoration: 'line-through' } : {}}>{item.process}</span>
         </div>
-        <div>
-          <span className='combobox-menu-entry-additional'>{`${item.project} > ${item.packageName}.${item.process}`}</span>
-        </div>
+        <div className='combobox-menu-entry-additional'>{` : ${item.startName} - ${item.packageName}`}</div>
       </>
     );
   };

--- a/packages/editor/src/components/parts/common/classification/ClassificationCombobox.tsx
+++ b/packages/editor/src/components/parts/common/classification/ClassificationCombobox.tsx
@@ -18,13 +18,9 @@ const ClassificationCombobox = ({ value, onChange, data, icon, withBrowser }: Cl
       <>
         <div>
           {icon && <IvyIcon icon={icon} />}
-          {item.label ? item.label : item.value}
+          <span>{item.label ? item.label : item.value}</span>
         </div>
-        {item.info && (
-          <div>
-            <span className='combobox-menu-entry-additional'>{item.info}</span>
-          </div>
-        )}
+        {item.info && <div className='combobox-menu-entry-additional'>{` - ${item.info}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/parts/common/exception-handler/ExceptionCombobox.tsx
+++ b/packages/editor/src/components/parts/common/exception-handler/ExceptionCombobox.tsx
@@ -21,11 +21,7 @@ export const ExceptionCombobox = ({ value, onChange, items, ...props }: Exceptio
           {item.icon && <IvyIcon icon={item.icon} />}
           {item.label}
         </div>
-        {item.info && (
-          <div>
-            <span className='combobox-menu-entry-additional'>{item.info}</span>
-          </div>
-        )}
+        {item.info && <div className='combobox-menu-entry-additional'>{` - ${item.info}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/parts/process-data/ClassSelectorPart.tsx
+++ b/packages/editor/src/components/parts/process-data/ClassSelectorPart.tsx
@@ -19,13 +19,7 @@ const DataClassSelector = ({ dataClass, onChange, dataClasses }: DataClassSelect
           <IvyIcon icon={IvyIcons.DataClass} />
           {item.name}
         </div>
-        {item.packageName && (
-          <div>
-            <span className='combobox-menu-entry-additional'>{item.packageName}</span>
-            <span className='combobox-menu-entry-additional'> - </span>
-            <span className='combobox-menu-entry-additional'>{item.path}</span>
-          </div>
-        )}
+        {item.packageName && <div className='combobox-menu-entry-additional'>{`${item.packageName} - ${item.path}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/parts/rest/rest-request/rest-target/RestMethodSelect.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-target/RestMethodSelect.tsx
@@ -29,11 +29,7 @@ export const RestMethodSelect = () => {
           <span className='combobox-method'>{item.method.httpMethod}</span>
           {item.path}
         </div>
-        {item.doc && item.doc.length > 0 && (
-          <div>
-            <span className='combobox-menu-entry-additional'>{item.doc}</span>
-          </div>
-        )}
+        {item.doc && item.doc.length > 0 && <div className='combobox-menu-entry-additional'>{` - ${item.doc}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/widgets/combobox/Combobox.css
+++ b/packages/editor/src/components/widgets/combobox/Combobox.css
@@ -34,7 +34,8 @@
 .combobox-menu-entry {
   padding: 0.5rem;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: var(--size-2);
   cursor: pointer;
   --basic-border: 1px solid var(--N200);
@@ -51,12 +52,13 @@
   color: var(--background);
 }
 .combobox-menu-entry-additional {
-  color: var(--seperator-color);
+  color: var(--N500);
 }
 .combobox-menu-entry > div {
   display: flex;
   align-items: center;
   gap: var(--size-1);
+  word-break: break-all;
 }
 .combobox-menu-entry .ivy {
   font-size: 1rem;


### PR DESCRIPTION
I have now adapted the combobox accordingly. Additional information is now displayed greyed out behind the "Main-Part". However, if there is not enough space for the additional information, it appears on the second line again and the words are wrapped accordingly so that you never have to scroll to the right to see the entire content.
![responsiveCombobox](https://github.com/axonivy/inscription-client/assets/141223521/8f2d3830-9f50-4caf-8ed8-534977a3a6d0)

I deliberately chose not to scroll to the right here, as I have the feeling that scrolling in the open combobox may not be quite so pleasant. The only downside to this approach could be that if there is a lot of text in the info, you may again have the problem that the combobox dropdown becomes extremely long. What do you think? Is it more important to have everything on one line (a short dropdown) or see everything at once (multiple lines)?

