### PR TITLE
XIVY-14428 Further improve Combobox-Layout

### DIFF
--- a/packages/editor/src/components/parts/call/CallSelect.tsx
+++ b/packages/editor/src/components/parts/call/CallSelect.tsx
@@ -17,7 +17,11 @@ const CallSelect = ({ start, onChange, starts, startIcon }: CallSelectProps) => 
   const items = useMemo<CallableStartItem[]>(
     () =>
       starts.map(start => {
-        return { ...start, value: start.id };
+        return {
+          ...start,
+          value: start.id,
+          tooltip: { main: `${start.process} : ${start.startName}`, additional: `${start.project} ${start.packageName}` }
+        };
       }),
     [starts]
   );
@@ -39,9 +43,9 @@ const CallSelect = ({ start, onChange, starts, startIcon }: CallSelectProps) => 
       <>
         <div>
           <IvyIcon icon={startIcon} />
-          <span style={item.deprecated ? { textDecoration: 'line-through' } : {}}>{item.process}</span>
+          <span style={item.deprecated ? { textDecoration: 'line-through' } : {}}>{`${item.process} : ${item.startName} `}</span>
         </div>
-        <div className='combobox-menu-entry-additional'>{` : ${item.startName} - ${item.packageName}`}</div>
+        <div className='combobox-menu-entry-additional'>{`[${item.project} ${item.packageName}]`}</div>
       </>
     );
   };

--- a/packages/editor/src/components/widgets/combobox/Combobox.css
+++ b/packages/editor/src/components/widgets/combobox/Combobox.css
@@ -35,8 +35,8 @@
   padding: 0.5rem;
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
   gap: var(--size-2);
+  overflow: hidden;
   cursor: pointer;
   --basic-border: 1px solid var(--N200);
   border-bottom: var(--basic-border);
@@ -54,12 +54,31 @@
 .combobox-menu-entry-additional {
   color: var(--N500);
 }
+.combobox-menu-entry-additional > div {
+  white-space: nowrap;
+
+  text-overflow: ellipsis;
+}
 .combobox-menu-entry > div {
   display: flex;
   align-items: center;
   gap: var(--size-1);
-  word-break: break-all;
+  white-space: nowrap;
 }
 .combobox-menu-entry .ivy {
   font-size: 1rem;
+}
+.ui-tooltip-content {
+  max-width: 350px;
+  word-break: break-all;
+}
+
+.tooltip-additional {
+  color: var(--N600);
+}
+
+@media (max-width: 360px) {
+  .ui-tooltip-content {
+    width: 200px;
+  }
 }

--- a/packages/editor/src/components/widgets/combobox/Combobox.tsx
+++ b/packages/editor/src/components/widgets/combobox/Combobox.tsx
@@ -4,7 +4,7 @@ import { memo, useEffect, useState } from 'react';
 import './Combobox.css';
 import { usePath } from '../../../context';
 import { IvyIcons } from '@axonivy/ui-icons';
-import { Button, Input, useField, useReadonly } from '@axonivy/ui-components';
+import { Button, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, useField, useReadonly } from '@axonivy/ui-components';
 import { SingleLineCodeEditor } from '../code-editor';
 import { useMonacoEditor } from '../code-editor/useCodeEditor';
 import type { BrowserType } from '../../../components/browser';
@@ -13,8 +13,14 @@ import { CardText } from '../output/CardText';
 import { useOnFocus } from '../../../components/browser/useOnFocus';
 import type { BrowserValue } from '../../browser/Browser';
 
+interface TooltipProps {
+  main: string;
+  additional?: string;
+}
+
 export interface ComboboxItem {
   value: string;
+  tooltip?: TooltipProps;
 }
 
 export type ComboboxProps<T extends ComboboxItem> = Omit<ComponentPropsWithRef<'input'>, 'value' | 'onChange'> & {
@@ -65,7 +71,7 @@ const Combobox = <T extends ComboboxItem>({
         switch (actionAndChanges.type) {
           case useCombobox.stateChangeTypes.InputBlur:
           case useCombobox.stateChangeTypes.InputKeyDownEnter:
-            selectItem({ value: actionAndChanges.changes.inputValue ?? '' });
+            selectItem({ value: actionAndChanges.changes.inputValue ?? '', tooltip: undefined } as T);
         }
         return actionAndChanges.changes;
       },
@@ -81,12 +87,12 @@ const Combobox = <T extends ComboboxItem>({
       itemToString(item) {
         return item?.value ?? '';
       },
-      initialSelectedItem: { value }
+      initialSelectedItem: { value, tooltip: undefined } as T
     });
 
   useEffect(() => {
     if (!updateOnInputChange || updateOnInputChange == undefined) {
-      selectItem({ value });
+      selectItem({ value, tooltip: undefined } as T);
       setFilteredItems(items);
     }
   }, [updateOnInputChange, items, selectItem, value]);
@@ -132,17 +138,43 @@ const Combobox = <T extends ComboboxItem>({
       </div>
       <ul {...getMenuProps()} className='combobox-menu'>
         {isOpen &&
-          filteredItems.map((item, index) => (
-            <li
-              className={`combobox-menu-entry ${highlightedIndex === index ? 'hover' : ''} ${
-                selectedItem?.value === item.value ? 'selected' : ''
-              }`}
-              key={`${item.value}${index}`}
-              {...getItemProps({ item, index })}
-            >
-              {option(item)}
-            </li>
-          ))}
+          filteredItems.map((item, index) =>
+            item.tooltip ? (
+              <TooltipProvider key={`${item.value}${index}`}>
+                <Tooltip delayDuration={700}>
+                  <TooltipTrigger asChild>
+                    <li
+                      className={`combobox-menu-entry ${highlightedIndex === index ? 'hover' : ''} ${
+                        selectedItem?.value === item.value ? 'selected' : ''
+                      }`}
+                      {...getItemProps({ item, index })}
+                    >
+                      {option(item)}
+                    </li>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <span>{item.tooltip.main}</span>
+                    {item.tooltip && item.tooltip.additional && (
+                      <>
+                        <br />
+                        <span className='tooltip-additional'>{item.tooltip.additional}</span>
+                      </>
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <li
+                key={`${item.value}${index}`}
+                className={`combobox-menu-entry ${highlightedIndex === index ? 'hover' : ''} ${
+                  selectedItem?.value === item.value ? 'selected' : ''
+                }`}
+                {...getItemProps({ item, index })}
+              >
+                {option(item)}
+              </li>
+            )
+          )}
       </ul>
     </div>
   );


### PR DESCRIPTION
I played around a bit with the combobox layout and added a tooltip option to the combobox. 
@ivy-lli, @ivy-rew  What do you think of this solution? I find it quite elegant. The only disadvantage is that there is no tooltip on mobile devices.
![furtherImproveDialog](https://github.com/axonivy/inscription-client/assets/141223521/73e72dc1-9850-4916-b45d-51783b388c23)

@ivy-lli Initially I wanted to add the tooltip directly in the comboboxItem within the Call itself, but unfortunately I always got a React error message here: "React.Children.only expected to receive a single React element child."
I have now simply extended the comboboxItem with the tooltip, but have to work with "as T" at the end in certain places to get rid of TypeScript error messages. What do you think? Maybe this tooltip complicates the combobox too much. 

I will certainly wait with this merge until we have also received feedback from bruno.