### PR TITLE
XIVY-14428 Improvement for Combobox-Layout

### DIFF
--- a/packages/editor/src/components/parts/call/CallSelect.tsx
+++ b/packages/editor/src/components/parts/call/CallSelect.tsx
@@ -35,13 +35,14 @@ const CallSelect = ({ start, onChange, starts, startIcon }: CallSelectProps) => 
   };
 
   const comboboxItem = (item: CallableStartItem) => {
+    const tooltip = `${item.process} : ${item.startName} - ${item.packageName}`;
     return (
       <>
-        <div>
+        <div title={tooltip} aria-label={tooltip}>
           <IvyIcon icon={startIcon} />
-          <span style={item.deprecated ? { textDecoration: 'line-through' } : {}}>{item.process}</span>
+          <span style={item.deprecated ? { textDecoration: 'line-through' } : {}}>{`${item.process} : ${item.startName} `}</span>
+          <span className='combobox-menu-entry-additional'>{` - ${item.packageName}`}</span>
         </div>
-        <div className='combobox-menu-entry-additional'>{` : ${item.startName} - ${item.packageName}`}</div>
       </>
     );
   };

--- a/packages/editor/src/components/parts/common/classification/ClassificationCombobox.tsx
+++ b/packages/editor/src/components/parts/common/classification/ClassificationCombobox.tsx
@@ -14,13 +14,14 @@ type ClassificatioComboboxProps = {
 
 const ClassificationCombobox = ({ value, onChange, data, icon, withBrowser }: ClassificatioComboboxProps) => {
   const comboboxItem = (item: ClassifiedItem) => {
+    const tooltip = `${item.label ? item.label : item.value}${item.info ?? ` - ${item.info}`}`;
     return (
       <>
-        <div>
+        <div title={tooltip} aria-label={tooltip}>
           {icon && <IvyIcon icon={icon} />}
           <span>{item.label ? item.label : item.value}</span>
+          {item.info && <span className='combobox-menu-entry-additional'>{` - ${item.info}`}</span>}
         </div>
-        {item.info && <div className='combobox-menu-entry-additional'>{` - ${item.info}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/parts/common/exception-handler/ExceptionCombobox.tsx
+++ b/packages/editor/src/components/parts/common/exception-handler/ExceptionCombobox.tsx
@@ -15,13 +15,14 @@ export type ExceptionItem = {
 
 export const ExceptionCombobox = ({ value, onChange, items, ...props }: ExceptionComboboxProps) => {
   const comboboxItem = (item: ExceptionItem) => {
+    const tooltip = `${item.label}${item.info ? ` - ${item.info}` : ''}`;
     return (
       <>
-        <div>
+        <div title={tooltip} aria-label={tooltip}>
           {item.icon && <IvyIcon icon={item.icon} />}
-          {item.label}
+          <span>{item.label}</span>
+          {item.info && <span className='combobox-menu-entry-additional'>{` - ${item.info}`}</span>}
         </div>
-        {item.info && <div className='combobox-menu-entry-additional'>{` - ${item.info}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/parts/process-data/ClassSelectorPart.tsx
+++ b/packages/editor/src/components/parts/process-data/ClassSelectorPart.tsx
@@ -13,13 +13,14 @@ type DataClassSelectorProps = {
 
 const DataClassSelector = ({ dataClass, onChange, dataClasses }: DataClassSelectorProps) => {
   const comboboxItem = (item: DataClassItem) => {
+    const tooltip = `${item.name} ${item.packageName ? `${item.packageName} - ${item.path}` : ''}`;
     return (
       <>
-        <div>
+        <div title={tooltip} aria-label={tooltip}>
           <IvyIcon icon={IvyIcons.DataClass} />
-          {item.name}
+          <span>{item.name}</span>
+          {item.packageName && <span className='combobox-menu-entry-additional'>{`${item.packageName} - ${item.path}`}</span>}
         </div>
-        {item.packageName && <div className='combobox-menu-entry-additional'>{`${item.packageName} - ${item.path}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/parts/rest/rest-request/rest-target/RestMethodSelect.tsx
+++ b/packages/editor/src/components/parts/rest/rest-request/rest-target/RestMethodSelect.tsx
@@ -23,13 +23,14 @@ export const RestMethodSelect = () => {
   const methodItems = useMemo<SelectItem[]>(() => Object.entries(HTTP_METHOD).map(([value, label]) => ({ label, value })), []);
 
   const comboboxItem = (item: RestMethodItem) => {
+    const tooltip = `${item.method.httpMethod} ${item.path}${item.doc && item.doc.length > 0 ? ` - ${item.doc}` : ''}`;
     return (
       <>
-        <div>
+        <div title={tooltip} aria-label={tooltip}>
           <span className='combobox-method'>{item.method.httpMethod}</span>
-          {item.path}
+          <span>{item.path}</span>
+          {item.doc && item.doc.length > 0 && <span className='combobox-menu-entry-additional'>{` - ${item.doc}`}</span>}
         </div>
-        {item.doc && item.doc.length > 0 && <div className='combobox-menu-entry-additional'>{` - ${item.doc}`}</div>}
       </>
     );
   };

--- a/packages/editor/src/components/widgets/combobox/Combobox.css
+++ b/packages/editor/src/components/widgets/combobox/Combobox.css
@@ -35,7 +35,7 @@
   padding: 0.5rem;
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
+  overflow: hidden;
   gap: var(--size-2);
   cursor: pointer;
   --basic-border: 1px solid var(--N200);
@@ -58,7 +58,8 @@
   display: flex;
   align-items: center;
   gap: var(--size-1);
-  word-break: break-all;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .combobox-menu-entry .ivy {
   font-size: 1rem;


### PR DESCRIPTION
The dialogue combo box is now structured as follows: 
MainDlg : start(data) - package name

Otherwise (following discussion from https://github.com/axonivy/inscription-client/pull/610) I have deactivated multiline-comboboxes. Everything is singleline and a tooltip is displayed on hover.
![finalCombobox](https://github.com/axonivy/inscription-client/assets/141223521/de8fb2b7-f54b-48a2-ad02-d7deb504a916)

