### PR TITLE
XIVY-14823 Add NewRole-Popover to RoleBrowser

### DIFF
--- a/integrations/standalone/package.json
+++ b/integrations/standalone/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@axonivy/inscription-core": "~12.0.0-next",
     "@axonivy/inscription-editor": "~12.0.0-next",
-    "@axonivy/ui-icons": "~12.0.0-next.372",
+    "@axonivy/ui-icons": "~12.0.0-next.374",
     "path-browserify": "^1.0.1"
   },
   "devDependencies": {

--- a/integrations/standalone/src/mock/inscription-client-mock.ts
+++ b/integrations/standalone/src/mock/inscription-client-mock.ts
@@ -73,6 +73,8 @@ export class InscriptionClientMock implements InscriptionClient {
         return Promise.resolve(MetaMock.CALLABLE_STARTS);
       case 'meta/workflow/roleTree':
         return Promise.resolve(MetaMock.ROLES);
+      case 'meta/workflow/addRole':
+        return Promise.resolve(MetaMock.ROLES);
       case 'meta/workflow/errorStarts':
         return Promise.resolve(MetaMock.EXPIRY_ERRORS);
       case 'meta/workflow/errorCodes':

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       "dependencies": {
         "@axonivy/inscription-core": "~12.0.0-next",
         "@axonivy/inscription-editor": "~12.0.0-next",
-        "@axonivy/ui-icons": "~12.0.0-next.372",
+        "@axonivy/ui-icons": "~12.0.0-next.374",
         "path-browserify": "^1.0.1"
       },
       "devDependencies": {
@@ -102,19 +102,17 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "12.0.0-next.372",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.372.tgz",
-      "integrity": "sha512-F+WH9/tgKhh6mfW7Jyssvtth7xEIiRfN9CYWVlcoq9IdHxUqRYV8yGDn58sKzoSRbC7HKh1a6enLXVnrAJ4nVA==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "12.0.0-next.374",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.0-next.374.tgz",
+      "integrity": "sha512-4ZWi582pFELHnSb8Vc4ZCWtfyIrma9s9IrOvtNufP+gxGg+FAitbKA08rvIUNhT0ZXZ/hwlLE6rXDtBaSvwoeQ==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "12.0.0-next.372",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.372.tgz",
-      "integrity": "sha512-I4EcUl4kkrW02F8616Z72H6eI4WsMSVyqmXVlYY/10p62akj5j3a/M9/JOBjZO/HP9e0sHYbIHS6wG9OlQm0Gg==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "12.0.0-next.374",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.0-next.374.tgz",
+      "integrity": "sha512-7o4OMoLjm/JoJUJeXh50+1t2sxlPD6UOaeRuZZC769SAtaPU/0zb4xNwIjTmZzjI1WXwnCPosM2Njh1MtsWHbw==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.1",
         "@radix-ui/react-checkbox": "1.1.2",
@@ -143,10 +141,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "12.0.0-next.372",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.372.tgz",
-      "integrity": "sha512-Lsdl8j2F9z5ZrJZd58JFhMZexZa/Vn46qFzphqBSyQ6cDDPusTFBcH2bqKKgJNVgTS35Fl0wiDVv9NvPLzmNgw==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
+      "version": "12.0.0-next.374",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.0-next.374.tgz",
+      "integrity": "sha512-x5XOFK+WjLgtyFL8bFgxl0Xx+UqQliXFdEY2bJmMl55YP65vQbvwNIJ2HoU0LOchfsKm++zo/Se9TutZTSqr7w=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -16868,7 +16865,7 @@
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
         "@axonivy/inscription-protocol": "~12.0.0-next",
-        "@axonivy/jsonrpc": "~12.0.0-next.372",
+        "@axonivy/jsonrpc": "~12.0.0-next.374",
         "monaco-editor": "^0.44.0",
         "monaco-editor-workers": "^0.44.0",
         "monaco-languageclient": "^6.6.1",
@@ -16882,7 +16879,7 @@
       "dependencies": {
         "@axonivy/inscription-core": "~12.0.0-next",
         "@axonivy/inscription-protocol": "~12.0.0-next",
-        "@axonivy/ui-components": "~12.0.0-next.372",
+        "@axonivy/ui-components": "~12.0.0-next.374",
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-dialog": "1.1.2",
         "@radix-ui/react-radio-group": "1.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@axonivy/inscription-protocol": "~12.0.0-next",
-    "@axonivy/jsonrpc": "~12.0.0-next.372",
+    "@axonivy/jsonrpc": "~12.0.0-next.374",
     "monaco-editor": "^0.44.0",
     "monaco-editor-workers": "^0.44.0",
     "monaco-languageclient": "^6.6.1",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@axonivy/inscription-core": "~12.0.0-next",
     "@axonivy/inscription-protocol": "~12.0.0-next",
-    "@axonivy/ui-components": "~12.0.0-next.372",
+    "@axonivy/ui-components": "~12.0.0-next.374",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-dialog": "1.1.2",
     "@radix-ui/react-radio-group": "1.2.1",

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.css';
 import type { ElementData, InscriptionData, InscriptionElementContext, ValidationResult, PID } from '@axonivy/inscription-protocol';
-import { PanelMessage, ReadonlyProvider, Spinner } from '@axonivy/ui-components';
+import { PanelMessage, ReadonlyProvider, Spinner, Toaster } from '@axonivy/ui-components';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { DataContextInstance, DEFAULT_EDITOR_CONTEXT, EditorContextInstance, useClient } from './context';
 import AppStateView from './AppStateView';
@@ -119,6 +119,7 @@ function App({ outline, app, pmv, pid }: InscriptionElementContext & Inscription
           </DataContextInstance.Provider>
         </EditorContextInstance.Provider>
       </ReadonlyProvider>
+      <Toaster closeButton={true} position='bottom-left' />
     </div>
   );
 }

--- a/packages/editor/src/components/browser/Browser.tsx
+++ b/packages/editor/src/components/browser/Browser.tsx
@@ -55,7 +55,7 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, role
 
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog open={open} onOpenChange={onOpenChange} modal={false}>
         <DialogTrigger asChild>
           <Button icon={IvyIcons.ListSearch} aria-label='Browser' />
         </DialogTrigger>

--- a/packages/editor/src/components/browser/role/AddRolePopover.tsx
+++ b/packages/editor/src/components/browser/role/AddRolePopover.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import {
+  BasicField,
+  Button,
+  Flex,
+  Input,
+  Message,
+  Popover,
+  PopoverArrow,
+  PopoverContent,
+  PopoverTrigger,
+  toast
+} from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { useFunction } from '../../../context/useFunction';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEditorContext } from '../../../context';
+import type { RoleMeta } from '@axonivy/inscription-protocol';
+import type { Table } from '@tanstack/react-table';
+import { useRoles } from '../../parts/common/responsible/useRoles';
+import { isValidRowSelected, newNameExists, newNameIsValid } from './validate-role';
+
+export const AddRolePopover = ({ value, table }: { value: string; table: Table<RoleMeta> }) => {
+  const [open, setOpen] = useState(false);
+  const { taskRoles } = useRoles();
+  const [newRoleName, setNewRoleName] = useState('');
+
+  const queryClient = useQueryClient();
+  const { context } = useEditorContext();
+  const addRole = useFunction(
+    'meta/workflow/addRole',
+    {
+      context,
+      newRole: { identifier: 'test', parent: 'Everybody' }
+    },
+    {
+      onSuccess: () => {
+        toast.info('Role successfully added');
+        queryClient.invalidateQueries({ queryKey: ['meta/workflow/roleTree', context] });
+        setOpen(false);
+      },
+      onError: error => {
+        toast.error('Failed to add new role', { description: error.message });
+      }
+    }
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={e => {
+        setOpen(e);
+        if (e) setNewRoleName('');
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          icon={IvyIcons.Plus}
+          aria-label={`Add Role to ${value}`}
+          title={`Add Role to ${value}`}
+          disabled={!isValidRowSelected(table, taskRoles)}
+        />
+      </PopoverTrigger>
+      <PopoverContent sideOffset={12} collisionPadding={5} style={{ zIndex: '10000' }}>
+        <Flex direction='column' gap={2} alignItems='center'>
+          <BasicField label='New role name' style={{ width: '100%' }}>
+            <Input value={newRoleName} onChange={e => setNewRoleName(e.target.value)} />
+          </BasicField>
+          {newNameExists(table, newRoleName) && <Message variant='error' message='A role with that name already exists' />}
+          <Button
+            icon={IvyIcons.Plus}
+            onClick={() => {
+              addRole.mutate({
+                context,
+                newRole: { identifier: newRoleName, parent: value }
+              });
+            }}
+            aria-label='Add new Role'
+            title='Add new Role'
+            disabled={!newNameIsValid(table, newRoleName)}
+            style={{ width: '100%' }}
+          >
+            Add Role to {value}
+          </Button>
+        </Flex>
+        <PopoverArrow />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/packages/editor/src/components/browser/role/RoleBrowser.tsx
+++ b/packages/editor/src/components/browser/role/RoleBrowser.tsx
@@ -15,7 +15,8 @@ import {
 } from '@tanstack/react-table';
 import { useRoles } from '../../parts/common/responsible/useRoles';
 import type { RoleMeta } from '@axonivy/inscription-protocol';
-import { SelectRow, TableBody, TableCell, TableRow } from '@axonivy/ui-components';
+import { Flex, SelectRow, TableBody, TableCell, TableRow } from '@axonivy/ui-components';
+import { AddRolePopover } from './AddRolePopover';
 export const ROLE_BROWSER = 'role' as const;
 
 export type RoleOptions = {
@@ -93,6 +94,9 @@ const RoleBrowser = (props: {
 
   return (
     <>
+      <Flex justifyContent='flex-end'>
+        <AddRolePopover value={props.value} table={table} />
+      </Flex>
       <SearchTable
         search={{
           value: globalFilter,

--- a/packages/editor/src/components/browser/role/validate-role.test.ts
+++ b/packages/editor/src/components/browser/role/validate-role.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+import type { RoleMeta } from '@axonivy/inscription-protocol';
+import type { Table } from '@tanstack/react-table'; // replace with the actual path
+import { isValidRowSelected, newNameExists, newNameIsValid } from './validate-role';
+
+const testTable = (rows: RoleMeta[], selectedRow?: RoleMeta): Table<RoleMeta> => {
+  return {
+    getRowModel: () => ({
+      flatRows: rows.map(row => ({ original: row }))
+    }),
+    getSelectedRowModel: () => ({
+      flatRows: selectedRow ? [{ original: selectedRow }] : []
+    })
+  } as Table<RoleMeta>;
+};
+
+describe('newNameExists', () => {
+  test('return true if the new role name exists in the table', () => {
+    const table = testTable([{ id: 'role1', children: [], label: 'Role 1' }]);
+    expect(newNameExists(table, 'role1')).toBe(true);
+  });
+
+  test('return false if the new role name does not exist in the table', () => {
+    const table = testTable([{ id: 'role2', children: [], label: 'Role 2' }]);
+    expect(newNameExists(table, 'role1')).toBe(false);
+  });
+});
+
+describe('newNameIsValid', () => {
+  test('return false if the new role name is empty', () => {
+    const table = testTable([{ id: 'role1', children: [], label: 'Role 1' }]);
+    expect(newNameIsValid(table, '')).toBe(false);
+  });
+
+  test('return false if the new role name already exists', () => {
+    const table = testTable([{ id: 'role1', children: [], label: 'Role 1' }]);
+    expect(newNameIsValid(table, 'role1')).toBe(false);
+  });
+
+  test('return false if the new role name only has whitespaces', () => {
+    const table = testTable([]);
+    expect(newNameIsValid(table, '   ')).toBe(false);
+  });
+
+  test('return true if the new role name is unique and non-empty', () => {
+    const table = testTable([{ id: 'role1', children: [], label: 'Role 1' }]);
+    expect(newNameIsValid(table, 'role2')).toBe(true);
+  });
+});
+
+describe('isValidRowSelected', () => {
+  test('return false if no row is selected', () => {
+    const table = testTable([{ id: 'role1', children: [], label: 'Role 1' }]);
+    expect(isValidRowSelected(table, [])).toBe(false);
+  });
+
+  test('return false if the selected row is in the task roles list', () => {
+    const selectedRole = { id: 'role1', children: [], label: 'Role 1' };
+    const table = testTable([selectedRole], selectedRole);
+    expect(isValidRowSelected(table, [selectedRole])).toBe(false);
+  });
+
+  test('return true if the selected row is not in the task roles list', () => {
+    const selectedRole = { id: 'role1', children: [], label: 'Role 1' };
+    const table = testTable([{ id: 'role2', children: [], label: 'Role 2' }], selectedRole);
+    expect(isValidRowSelected(table, [{ id: 'role3', children: [], label: 'Role 3' }])).toBe(true);
+  });
+});

--- a/packages/editor/src/components/browser/role/validate-role.ts
+++ b/packages/editor/src/components/browser/role/validate-role.ts
@@ -1,0 +1,23 @@
+import type { RoleMeta } from '@axonivy/inscription-protocol';
+import type { Table } from '@tanstack/react-table';
+
+export const newNameExists = (table: Table<RoleMeta>, newRoleName: string): boolean => {
+  return table.getRowModel().flatRows.some(row => row.original.id === newRoleName);
+};
+
+export const newNameIsValid = (table: Table<RoleMeta>, newRoleName: string): boolean => {
+  if (newRoleName.length === 0 || newRoleName.trim().length === 0) {
+    return false;
+  }
+  if (newNameExists(table, newRoleName)) {
+    return false;
+  }
+  return true;
+};
+
+export const isValidRowSelected = (table: Table<RoleMeta>, taskRoles: RoleMeta[]): boolean => {
+  const selectedRow = table.getSelectedRowModel().flatRows[0]?.original;
+  if (!selectedRow) return false;
+
+  return !taskRoles.some(role => role.id === selectedRow.id);
+};

--- a/packages/editor/src/components/parts/common/responsible/useRoles.ts
+++ b/packages/editor/src/components/parts/common/responsible/useRoles.ts
@@ -29,5 +29,5 @@ export const useRoles = (showTaskRoles = false) => {
     setRoles(flatRoles);
   }, [roleTree, setRolesAsTree, showTaskRoles, taskRoles]);
 
-  return { rolesAsTree, roles };
+  return { rolesAsTree, roles, taskRoles };
 };

--- a/packages/editor/src/context/useFunction.ts
+++ b/packages/editor/src/context/useFunction.ts
@@ -1,0 +1,23 @@
+import type { InscriptionMetaRequestTypes } from '@axonivy/inscription-protocol';
+import { useClient } from './useClient';
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { genQueryKey } from '../query';
+type UseFunctionOptions<TData> = {
+  onSuccess?: (data: TData) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useFunction<TFunct extends keyof InscriptionMetaRequestTypes>(
+  path: TFunct,
+  initialArgs: InscriptionMetaRequestTypes[TFunct][0],
+  options?: UseFunctionOptions<InscriptionMetaRequestTypes[TFunct][1]>
+): UseMutationResult<InscriptionMetaRequestTypes[TFunct][1], Error, InscriptionMetaRequestTypes[TFunct][0] | undefined> {
+  const client = useClient();
+
+  return useMutation({
+    mutationKey: genQueryKey([path, initialArgs]),
+    mutationFn: (args?: InscriptionMetaRequestTypes[TFunct][0]) => client.meta(path, args ?? initialArgs),
+    onSuccess: options?.onSuccess,
+    onError: options?.onError
+  });
+}

--- a/packages/editor/src/query/query-client.ts
+++ b/packages/editor/src/query/query-client.ts
@@ -3,3 +3,7 @@ import { QueryClient } from '@tanstack/react-query';
 export const initQueryClient = () => {
   return new QueryClient();
 };
+
+export const genQueryKey = (...args: unknown[]) => {
+  return ['inscription', ...args];
+};

--- a/packages/protocol/src/data/inscription.ts
+++ b/packages/protocol/src/data/inscription.ts
@@ -26,6 +26,7 @@ export type Widget = Script | Label | Text;
 export type WidgetType = "TEXT" | "LABEL" | "SCRIPT";
 
 export interface Inscription {
+  addRoleRequest: AddRoleRequest;
   apiDocRequest: ApiDocRequest;
   boolean: boolean;
   callableDialogRequest: CallableDialogRequest;
@@ -76,15 +77,23 @@ export interface Inscription {
   workflowTypeRequest: WorkflowTypeRequest;
   [k: string]: unknown;
 }
+export interface AddRoleRequest {
+  context: InscriptionContext;
+  newRole: AddNewRole;
+}
+export interface InscriptionContext {
+  app: string;
+  pmv: string;
+}
+export interface AddNewRole {
+  identifier: string;
+  parent: string;
+}
 export interface ApiDocRequest {
   context: InscriptionContext;
   method: string;
   paramTypes: string[];
   type: string;
-}
-export interface InscriptionContext {
-  app: string;
-  pmv: string;
 }
 export interface CallableDialogRequest {
   context: InscriptionContext;

--- a/packages/protocol/src/inscription-protocol.ts
+++ b/packages/protocol/src/inscription-protocol.ts
@@ -40,7 +40,8 @@ import type {
   CategoryPathMeta,
   WorkflowTypeRequest,
   WfCustomField,
-  OutlineNode
+  OutlineNode,
+  AddRoleRequest
 } from './data/inscription';
 import type { InscriptionData, InscriptionSaveData } from './data/inscription-data';
 
@@ -51,6 +52,7 @@ export interface InscriptionMetaRequestTypes {
 
   'meta/workflow/roleTree': [InscriptionContext, RoleMeta];
   'meta/workflow/taskRoles': [InscriptionElementContext, RoleMeta[]];
+  'meta/workflow/addRole': [AddRoleRequest, RoleMeta];
   'meta/workflow/errorStarts': [InscriptionElementContext, ErrorStartMeta[]];
   'meta/workflow/errorCodes': [ErrorCodeRequest, EventCodeMeta[]];
   'meta/workflow/signalCodes': [SignalCodeRequest, EventCodeMeta[]];

--- a/playwright/tests/integration/mock/browser/browser-mock-utils.ts
+++ b/playwright/tests/integration/mock/browser/browser-mock-utils.ts
@@ -20,15 +20,16 @@ export function browserBtn(page: Page) {
 
 export async function applyBrowser(page: Page, browser: string, expectedSelection: string = '', rowToCheck: number, dblClick?: boolean) {
   await browserBtn(page).nth(0).click();
-  await expect(page.getByRole('dialog')).toBeVisible();
-  await page.getByText(browser).first().click();
-  await page.getByRole('row').nth(rowToCheck).click();
+  const browserDialog = page.getByRole('dialog');
+  await expect(browserDialog).toBeVisible();
+  await browserDialog.getByText(browser).first().click();
+  await browserDialog.getByRole('row').nth(rowToCheck).click();
 
   if (dblClick) {
-    await page.getByRole('row').nth(rowToCheck).dblclick();
+    await browserDialog.getByRole('row').nth(rowToCheck).dblclick();
   } else {
-    await expect(page.locator('.browser-helptext')).toHaveText(expectedSelection);
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await expect(browserDialog.locator('.browser-helptext')).toHaveText(expectedSelection);
+    await browserDialog.getByRole('button', { name: 'Apply' }).click();
   }
 
   await expect(page.getByRole('dialog')).toBeHidden();

--- a/playwright/tests/integration/mock/browser/tableCol.spec.ts
+++ b/playwright/tests/integration/mock/browser/tableCol.spec.ts
@@ -56,19 +56,20 @@ test('browser add table column doubleclick', async ({ page }) => {
 
 async function applyTableColBrowser(page: Page, expectedSelection: string = '', rowToCheck: number, numberOfRows?: number, dblClick?: boolean) {
   await browserBtn(page).nth(0).click();
-  await expect(page.getByRole('dialog')).toBeVisible();
-  await page.getByText('Table Column').first().click();
+  const browserDialog = page.getByRole('dialog');
+  await expect(browserDialog).toBeVisible();
+  await browserDialog.getByText('Table Column').first().click();
 
   if (dblClick) {
-    await page.getByRole('row').nth(rowToCheck).click();
-    await page.getByRole('row').nth(rowToCheck).dblclick();
+    await browserDialog.getByRole('row').nth(rowToCheck).click();
+    await browserDialog.getByRole('row').nth(rowToCheck).dblclick();
   } else {
     if (numberOfRows) {
-      expect(page.getByRole('row')).toHaveCount(numberOfRows);
+      expect(browserDialog.getByRole('row')).toHaveCount(numberOfRows);
     }
-    await page.getByRole('row').nth(rowToCheck).click();
-    await expect(page.locator('.browser-helptext')).toHaveText(expectedSelection);
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await browserDialog.getByRole('row').nth(rowToCheck).click();
+    await expect(browserDialog.locator('.browser-helptext')).toHaveText(expectedSelection);
+    await browserDialog.getByRole('button', { name: 'Apply' }).click();
   }
 
   await expect(page.getByRole('dialog')).toBeHidden();

--- a/playwright/tests/integration/mock/browser/type.spec.ts
+++ b/playwright/tests/integration/mock/browser/type.spec.ts
@@ -69,20 +69,21 @@ test('browser add type doubleclick', async ({ page }) => {
 
 async function applyTypeBrowser(page: Page, rowToCheck: number, expectedSelection: string = '', checkListGeneric?: boolean, dblClick?: boolean) {
   await browserBtn(page).nth(0).click();
-  await expect(page.getByRole('dialog')).toBeVisible();
-  await page.getByText('Type').first().click();
-  await page.getByRole('row').nth(rowToCheck).click();
+  const browserDialog = page.getByRole('dialog');
+  await expect(browserDialog).toBeVisible();
+  await browserDialog.getByText('Type').first().click();
+  await browserDialog.getByRole('row').nth(rowToCheck).click();
 
   if (dblClick) {
-    await page.getByRole('row').nth(rowToCheck).dblclick();
+    await browserDialog.getByRole('row').nth(rowToCheck).dblclick();
   } else {
     if (checkListGeneric) {
-      await page.getByLabel('Use Type as List').click();
-      await expect(page.locator('.browser-helptext')).toHaveText('List<' + expectedSelection + '>');
+      await browserDialog.getByLabel('Use Type as List').click();
+      await expect(browserDialog.locator('.browser-helptext')).toHaveText('List<' + expectedSelection + '>');
     } else {
-      await expect(page.locator('.browser-helptext')).toHaveText(expectedSelection);
+      await expect(browserDialog.locator('.browser-helptext')).toHaveText(expectedSelection);
     }
-    await page.getByRole('button', { name: 'Apply' }).click();
+    await browserDialog.getByRole('button', { name: 'Apply' }).click();
   }
 
   await expect(page.getByRole('dialog')).toBeHidden();


### PR DESCRIPTION
My proposal for the AddRole functionality in the Type Browser (Core: https://github.com/axonivy/core/pull/7186). 

Certain validations are currently implemented directly in the frontend; it might make more sense to move these to the backend in the future?

Open To-Dos:
- Write tests
- Equip the CMS browser with the same query invalidation for the Add CMS functionality
- Later, I might try to have the newly added role automatically selected in a separate PR. What do you think of this feature?
![newRole](https://github.com/user-attachments/assets/a7879192-42e7-47cf-adef-aadafa34a0c4)

