### PR TITLE
XIVY-14823 refactor newCmsString-Action to a function

### DIFF
--- a/packages/editor/src/components/browser/Browser.tsx
+++ b/packages/editor/src/components/browser/Browser.tsx
@@ -24,6 +24,7 @@ type BrowserProps = UseBrowserReturnValue & {
 
 const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, roleOptions, initSearchFilter }: BrowserProps) => {
   const [active, setActive] = useState<BrowserType>(types[0]);
+  const [disableApply, setDisableApply] = useState(false);
 
   const acceptBrowser = () => {
     accept(allBrowsers.find(browser => browser.id === active)?.accept() ?? { cursorValue: '' }, active);
@@ -35,7 +36,7 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, role
   };
 
   const attrBrowser = useAttributeBrowser(onRowDoubleClick, location);
-  const cmsBrowser = useCmsBrowser(onRowDoubleClick, location, cmsOptions);
+  const cmsBrowser = useCmsBrowser(onRowDoubleClick, location, setDisableApply, cmsOptions);
   const funcBrowser = useFuncBrowser(onRowDoubleClick);
   const typeBrowser = useTypeBrowser(
     onRowDoubleClick,
@@ -65,6 +66,7 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, role
           onApply={() => acceptBrowser()}
           open={open}
           tabs={tabs}
+          disableApply={disableApply}
         />
       </Dialog>
     </>

--- a/packages/editor/src/components/browser/BrowserBody.tsx
+++ b/packages/editor/src/components/browser/BrowserBody.tsx
@@ -10,9 +10,10 @@ interface ReusableBrowserDialogProps {
   activeTab: string;
   onTabsChange?: (change: string) => void;
   onApply?: () => void;
+  disableApply?: boolean;
 }
 
-const BrowserBody = ({ open, tabs, activeTab, onTabsChange, onApply }: ReusableBrowserDialogProps) => {
+const BrowserBody = ({ open, tabs, activeTab, onTabsChange, onApply, disableApply }: ReusableBrowserDialogProps) => {
   const { editorRef } = useEditorContext();
 
   return (
@@ -33,7 +34,7 @@ const BrowserBody = ({ open, tabs, activeTab, onTabsChange, onApply }: ReusableB
               </Button>
             </DialogClose>
             <DialogClose asChild>
-              <Button aria-label='Apply' onClick={onApply} size='large' variant='primary'>
+              <Button aria-label='Apply' onClick={onApply} size='large' variant='primary' disabled={disableApply}>
                 Apply
               </Button>
             </DialogClose>

--- a/packages/editor/src/components/browser/cms/CmsBrowser.test.tsx
+++ b/packages/editor/src/components/browser/cms/CmsBrowser.test.tsx
@@ -4,7 +4,11 @@ import { describe, test, expect } from 'vitest';
 import type { BrowserValue } from '../Browser';
 
 const Browser = (props: { location: string; accept: (value: BrowserValue) => void }) => {
-  const browser = useCmsBrowser(() => {}, props.location);
+  const browser = useCmsBrowser(
+    () => {},
+    props.location,
+    () => {}
+  );
   return (
     <>
       {browser.content}

--- a/packages/protocol/src/data/inscription.ts
+++ b/packages/protocol/src/data/inscription.ts
@@ -50,6 +50,7 @@ export interface Inscription {
   inscriptionRequest: InscriptionRequest;
   inscriptionSaveRequest: InscriptionSaveRequest;
   javaType: JavaType[];
+  newCmsStringRequest: NewCmsStringRequest;
   outlineNode: OutlineNode;
   programEditorRequest: ProgramEditorRequest;
   programInterface: ProgramInterface[];
@@ -277,7 +278,6 @@ export interface PublicType {
 }
 export interface InscriptionActionArgs {
   actionId:
-    | "newCmsString"
     | "newHtmlDialog"
     | "newProcess"
     | "newProgram"
@@ -288,7 +288,8 @@ export interface InscriptionActionArgs {
     | "openEndPage"
     | "openOrCreateCmsCategory"
     | "openPage"
-    | "openProgram";
+    | "openProgram"
+    | "openUrl";
   context: InscriptionElementContext;
   payload: string | OpenCustomField;
 }
@@ -721,6 +722,10 @@ export interface JavaType {
   fullQualifiedName: string;
   packageName: string;
   simpleName: string;
+}
+export interface NewCmsStringRequest {
+  context: InscriptionContext;
+  parentUri: string;
 }
 export interface OutlineNode {
   children: OutlineNode[];

--- a/packages/protocol/src/inscription-protocol.ts
+++ b/packages/protocol/src/inscription-protocol.ts
@@ -41,7 +41,8 @@ import type {
   WorkflowTypeRequest,
   WfCustomField,
   OutlineNode,
-  AddRoleRequest
+  AddRoleRequest,
+  NewCmsStringRequest
 } from './data/inscription';
 import type { InscriptionData, InscriptionSaveData } from './data/inscription-data';
 
@@ -96,6 +97,7 @@ export interface InscriptionMetaRequestTypes {
   'meta/program/editor': [ProgramEditorRequest, Widget[]];
 
   'meta/cms/tree': [CmsMetaRequest, ContentObject[]];
+  'meta/cms/newCmsString': [NewCmsStringRequest, void];
 
   'meta/connector/out': [InscriptionElementContext, ConnectorRef[]];
 


### PR DESCRIPTION
I would like to remove the refresh button from the CMS browser so that whenever a new CMS string is added via the SWT dialog, the data is refreshed automatically. I am using the same architecture as in the combine function in the data class editor for this.

![newCmsString](https://github.com/user-attachments/assets/5b21974c-e869-4c2f-a89d-1cef7b7dc04a)
