### PR TITLE
XIVY-14823 Autoselect and expand newly added role

### DIFF
--- a/packages/editor/src/components/browser/role/AddRolePopover.tsx
+++ b/packages/editor/src/components/browser/role/AddRolePopover.tsx
@@ -16,11 +16,19 @@ import { useFunction } from '../../../context/useFunction';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEditorContext } from '../../../context';
 import type { RoleMeta } from '@axonivy/inscription-protocol';
-import type { Table } from '@tanstack/react-table';
+import { type Table } from '@tanstack/react-table';
 import { useRoles } from '../../parts/common/responsible/useRoles';
 import { isValidRowSelected, newNameExists, newNameIsValid } from './validate-role';
 
-export const AddRolePopover = ({ value, table }: { value: string; table: Table<RoleMeta> }) => {
+export const AddRolePopover = ({
+  value,
+  table,
+  setAddedRoleName
+}: {
+  value: string;
+  table: Table<RoleMeta>;
+  setAddedRoleName: (value: string) => void;
+}) => {
   const [open, setOpen] = useState(false);
   const { taskRoles } = useRoles();
   const [newRoleName, setNewRoleName] = useState('');
@@ -74,6 +82,7 @@ export const AddRolePopover = ({ value, table }: { value: string; table: Table<R
                 context,
                 newRole: { identifier: newRoleName, parent: value }
               });
+              setAddedRoleName(newRoleName);
             }}
             aria-label='Add new Role'
             title='Add new Role'

--- a/packages/editor/src/components/browser/role/RoleBrowser.tsx
+++ b/packages/editor/src/components/browser/role/RoleBrowser.tsx
@@ -92,10 +92,23 @@ const RoleBrowser = (props: {
     props.onChange({ cursorValue: selectedRow.original.id });
   }, [props, rowSelection, table]);
 
+  const [addedRole, setAddedRoleName] = useState('');
+
+  useEffect(() => {
+    if (addedRole.length === 0) {
+      return;
+    }
+    const newRow = table.getRowModel().flatRows.find(row => row.original.id === addedRole);
+    if (newRow) {
+      newRow.getParentRow()?.toggleExpanded(true);
+      setRowSelection({ [newRow.id]: true });
+    }
+  }, [addedRole, roleItems, table]);
+
   return (
     <>
       <Flex justifyContent='flex-end'>
-        <AddRolePopover value={props.value} table={table} />
+        <AddRolePopover value={props.value} table={table} setAddedRoleName={setAddedRoleName} />
       </Flex>
       <SearchTable
         search={{


### PR DESCRIPTION
To implement this auto-select feature, I had to use two useEffect hooks. Initially, I thought I could just change the selection in onSuccess, but it takes some time for the table to render with the new data. I could either use a setTimeout in onSuccess (not ideal) or use these useEffects to update the selection when a new role is detected. What do you think?

![autoSelectNewRole](https://github.com/user-attachments/assets/9fa2029d-592b-4dd1-a643-4ff8467ecacf)
