### PR TITLE
XIVY-14823 Reset newRoleName on autoSelection & add role via enter

### DIFF
--- a/packages/editor/src/components/browser/role/AddRolePopover.tsx
+++ b/packages/editor/src/components/browser/role/AddRolePopover.tsx
@@ -69,29 +69,33 @@ export const AddRolePopover = ({
           disabled={!isValidRowSelected(table, taskRoles)}
         />
       </PopoverTrigger>
-      <PopoverContent sideOffset={12} collisionPadding={5} style={{ zIndex: '10000' }}>
-        <Flex direction='column' gap={2} alignItems='center'>
-          <BasicField label='New role name' style={{ width: '100%' }}>
-            <Input value={newRoleName} onChange={e => setNewRoleName(e.target.value)} />
-          </BasicField>
-          {newNameExists(table, newRoleName) && <Message variant='error' message='A role with that name already exists' />}
-          <Button
-            icon={IvyIcons.Plus}
-            onClick={() => {
-              addRole.mutate({
-                context,
-                newRole: { identifier: newRoleName, parent: value }
-              });
-              setAddedRoleName(newRoleName);
-            }}
-            aria-label='Add new Role'
-            title='Add new Role'
-            disabled={!newNameIsValid(table, newRoleName)}
-            style={{ width: '100%' }}
-          >
-            Add Role to {value}
-          </Button>
-        </Flex>
+      <PopoverContent collisionPadding={5} style={{ zIndex: '10000' }}>
+        <form onSubmit={event => event.preventDefault()}>
+          <Flex direction='column' gap={2} alignItems='center'>
+            <BasicField label='New role name' style={{ width: '100%' }}>
+              <Input value={newRoleName} onChange={e => setNewRoleName(e.target.value)} />
+            </BasicField>
+            {newNameExists(table, newRoleName) && <Message variant='error' message='A role with that name already exists' />}
+            <Button
+              icon={IvyIcons.Plus}
+              onClick={() => {
+                addRole.mutate({
+                  context,
+                  newRole: { identifier: newRoleName, parent: value }
+                });
+                setAddedRoleName(newRoleName);
+              }}
+              aria-label='Add new Role'
+              title='Add new Role'
+              disabled={!newNameIsValid(table, newRoleName)}
+              style={{ width: '100%' }}
+              variant='primary'
+              type='submit'
+            >
+              Add Role to {value}
+            </Button>
+          </Flex>
+        </form>
         <PopoverArrow />
       </PopoverContent>
     </Popover>

--- a/packages/editor/src/components/browser/role/RoleBrowser.tsx
+++ b/packages/editor/src/components/browser/role/RoleBrowser.tsx
@@ -102,6 +102,7 @@ const RoleBrowser = (props: {
     if (newRow) {
       newRow.getParentRow()?.toggleExpanded(true);
       setRowSelection({ [newRow.id]: true });
+      setAddedRoleName('');
     }
   }, [addedRole, roleItems, table]);
 


### PR DESCRIPTION
As you suggested, I reset the addedRoleName after the selection.
I have also changed the appearance of the Add Role button to ‘Primary’ and added the option to add the role directly with ‘Enter’ after you typed in a valid role name.
![grafik](https://github.com/user-attachments/assets/76968cdf-ce30-4e96-835e-a2e0ff973eb8)
